### PR TITLE
feat: Add --version flag to CLI

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,8 +1,11 @@
+import argparse
 import os
 import sys
 import yaml
 from pathlib import Path
 from dotenv import load_dotenv
+
+__version__ = "0.3.0"
 
 
 def check_setup() -> tuple[bool, list[str]]:
@@ -67,6 +70,17 @@ def show_setup_guide(missing: list[str]):
 
 
 def main():
+    # Argument parsing
+    parser = argparse.ArgumentParser(
+        description="Network Agent - KI-gesteuerter Netzwerk-Scanner"
+    )
+    parser.add_argument(
+        "--version", "-v",
+        action="version",
+        version=f"Network Agent v{__version__}"
+    )
+    parser.parse_args()
+
     # Load environment variables
     load_dotenv()
 


### PR DESCRIPTION
## Summary
- Add `--version` / `-v` flag to display version info
- Add `__version__ = "0.3.0"` module constant
- Uses argparse for argument handling

## Test plan
- [x] `act push` passed (lint, docker)
- [x] `docker run network-agent --version` returns `Network Agent v0.3.0`

Closes #9

Generated with [Claude Code](https://claude.com/claude-code)