### PR TITLE
docs: Update README and version for slash commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2] - 2026-01-09
+
+### Added
+- **Slash Commands**: CLI commands now use `/` prefix (`/help`, `/clear`, `/exit`)
+- **Help Command**: `/help` shows available commands
+
+### Changed
+- **Startup Message**: Now shows "Type /help for available commands"
+
 ## [0.3.1] - 2026-01-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Network Agent
 
-[![Version](https://img.shields.io/badge/version-0.3.1-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.3.2-blue.svg)](CHANGELOG.md)
 
 Ein KI-gesteuerter Netzwerk-Scanner. Statt komplizierte Terminal-Befehle zu lernen, stellst du einfach Fragen wie *"Welche Geräte sind in meinem Netzwerk?"* - der Agent erledigt den Rest.
 
@@ -143,7 +143,7 @@ Nach dem Start siehst du:
 ```
 Network Agent startet...
    Model: gpt-4
-   Type 'exit' to stop, 'clear' to reset session
+   Type /help for available commands
 
    Context-Limit: 8,192 tokens
 
@@ -156,8 +156,9 @@ Jetzt kannst du Fragen stellen:
 - `Wer ist online im Subnetz 192.168.178.0/24?`
 
 **Commands:**
-- `clear` / `reset` - Session-Speicher löschen
-- `exit` / `quit` - Beenden
+- `/help` - Verfügbare Befehle anzeigen
+- `/clear` - Session-Speicher löschen
+- `/exit` - Beenden
 
 ## Plattform-Kompatibilität
 

--- a/cli.py
+++ b/cli.py
@@ -5,7 +5,7 @@ import yaml
 from pathlib import Path
 from dotenv import load_dotenv
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 
 
 def check_setup() -> tuple[bool, list[str]]:


### PR DESCRIPTION
## Summary
- Update startup message to show '/help for available commands'
- Update Commands section with slash prefix (`/help`, `/clear`, `/exit`)
- Add CHANGELOG entry for 0.3.2
- Bump version from 0.3.1 to 0.3.2
- Update README badge to 0.3.2

## Test plan
- [x] `act push -j lint -j docker` passed
- [x] Docker build successful
- [x] `--version` shows 0.3.2

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)