### PR TITLE
feat: Add /version slash command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.3] - 2026-01-09
+
+### Added
+- **Version Command**: `/version` displays current version in CLI (#14)
+
 ## [0.3.2] - 2026-01-09
 
 ### Added

--- a/cli.py
+++ b/cli.py
@@ -5,7 +5,7 @@ import yaml
 from pathlib import Path
 from dotenv import load_dotenv
 
-__version__ = "0.3.2"
+__version__ = "0.3.3"
 
 
 def check_setup() -> tuple[bool, list[str]]:
@@ -133,11 +133,16 @@ def main():
                     print("[Session zurückgesetzt]")
                     continue
 
+                if cmd == "/version":
+                    print(f"Network Agent v{__version__}")
+                    continue
+
                 if cmd == "/help":
                     print("Commands:")
-                    print("  /help  - Show available commands")
-                    print("  /clear - Reset session")
-                    print("  /exit  - Quit")
+                    print("  /help    - Show available commands")
+                    print("  /version - Show version")
+                    print("  /clear   - Reset session")
+                    print("  /exit    - Quit")
                     continue
 
                 # Unknown slash command


### PR DESCRIPTION
## Summary
- Add `/version` command to display current version in CLI
- Update `/help` to show `/version` in command list
- Version bump to 0.3.3

## Test Plan
- [x] `act push -j lint` passed
- [x] `act push -j docker` passed
- [x] Manual test: `/version` shows `Network Agent v0.3.3`
- [x] Manual test: `/help` lists `/version`
- [x] Manual test: `--version` CLI flag works

Closes #14

🤖 Generated with [Claude Code](https://claude.ai/claude-code)