### PR TITLE
docs: Add /version to README commands section

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Jetzt kannst du Fragen stellen:
 
 **Commands:**
 - `/help` - Verfügbare Befehle anzeigen
+- `/version` - Version anzeigen
 - `/clear` - Session-Speicher löschen
 - `/exit` - Beenden
 


### PR DESCRIPTION
## Summary
- Add `/version` command to README Commands section (was missing after #14)

## Test plan
- [x] Documentation change only

Closes: Documentation fix for #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)