### PR TITLE
feat: Add /status command for session statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.4] - 2026-01-09
+
+### Added
+- **Status Command**: `/status` displays session statistics (tokens used, context usage, truncations) (#17)
+
 ## [0.3.3] - 2026-01-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Network Agent
 
-[![Version](https://img.shields.io/badge/version-0.3.3-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.3.4-blue.svg)](CHANGELOG.md)
 
 Ein KI-gesteuerter Netzwerk-Scanner. Statt komplizierte Terminal-Befehle zu lernen, stellst du einfach Fragen wie *"Welche Geräte sind in meinem Netzwerk?"* - der Agent erledigt den Rest.
 
@@ -157,6 +157,7 @@ Jetzt kannst du Fragen stellen:
 
 **Commands:**
 - `/help` - Verfügbare Befehle anzeigen
+- `/status` - Session-Statistik anzeigen (Tokens, Context-Auslastung, Truncations)
 - `/version` - Version anzeigen
 - `/clear` - Session-Speicher löschen
 - `/exit` - Beenden

--- a/cli.py
+++ b/cli.py
@@ -5,7 +5,7 @@ import yaml
 from pathlib import Path
 from dotenv import load_dotenv
 
-__version__ = "0.3.3"
+__version__ = "0.3.4"
 
 
 def check_setup() -> tuple[bool, list[str]]:
@@ -135,9 +135,22 @@ def main():
                     print(f"Network Agent v{__version__}")
                     continue
 
+                if cmd == "/status":
+                    limit = agent.context_limit
+                    used = agent.last_prompt_tokens
+                    pct = agent.context_usage_percent
+                    total = agent.total_tokens
+                    truncations = agent.truncation_count
+                    print("Session Status:")
+                    print(f"  Context: {used:,}/{limit:,} tokens ({pct:.1f}%)")
+                    print(f"  Session Tokens: {total:,}")
+                    print(f"  Truncations: {truncations}")
+                    continue
+
                 if cmd == "/help":
                     print("Commands:")
                     print("  /help    - Show available commands")
+                    print("  /status  - Show session statistics")
                     print("  /version - Show version")
                     print("  /clear   - Reset session")
                     print("  /exit    - Quit")


### PR DESCRIPTION
## Summary
- Adds `/status` command showing current session statistics
- Displays context usage (tokens/limit with percentage)
- Shows total session tokens consumed
- Reports truncation count

Closes #17

## Test plan
- [x] Lokale CI grün (lint, test, security, docker)
- [x] Docker Build erfolgreich
- [x] Output-Format verifiziert
- [ ] GitHub Actions CI grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)