### PR TITLE
feat: Add /tools command to list available tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.5] - 2026-01-09
+
+### Added
+- **Tools Command**: `/tools` lists all available tools with name and description (#19)
+
 ## [0.3.4] - 2026-01-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Network Agent
 
-[![Version](https://img.shields.io/badge/version-0.3.4-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.3.5-blue.svg)](CHANGELOG.md)
 
 Ein KI-gesteuerter Netzwerk-Scanner. Statt komplizierte Terminal-Befehle zu lernen, stellst du einfach Fragen wie *"Welche Geräte sind in meinem Netzwerk?"* - der Agent erledigt den Rest.
 
@@ -157,6 +157,7 @@ Jetzt kannst du Fragen stellen:
 
 **Commands:**
 - `/help` - Verfügbare Befehle anzeigen
+- `/tools` - Verfügbare Tools auflisten (Name + Beschreibung)
 - `/status` - Session-Statistik anzeigen (Tokens, Context-Auslastung, Truncations)
 - `/version` - Version anzeigen
 - `/clear` - Session-Speicher löschen

--- a/cli.py
+++ b/cli.py
@@ -5,7 +5,7 @@ import yaml
 from pathlib import Path
 from dotenv import load_dotenv
 
-__version__ = "0.3.4"
+__version__ = "0.3.5"
 
 
 def check_setup() -> tuple[bool, list[str]]:
@@ -147,9 +147,22 @@ def main():
                     print(f"  Truncations: {truncations}")
                     continue
 
+                if cmd == "/tools":
+                    print("Available Tools:")
+                    for tool in agent.tools:
+                        # Truncate description to first sentence or 60 chars
+                        desc = tool.description
+                        if ". " in desc:
+                            desc = desc.split(". ")[0] + "."
+                        elif len(desc) > 60:
+                            desc = desc[:57] + "..."
+                        print(f"  {tool.name} - {desc}")
+                    continue
+
                 if cmd == "/help":
                     print("Commands:")
                     print("  /help    - Show available commands")
+                    print("  /tools   - List available tools")
                     print("  /status  - Show session statistics")
                     print("  /version - Show version")
                     print("  /clear   - Reset session")

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -72,16 +72,109 @@ class TestStatusCommand:
         assert "Truncations: 3" in result
 
 
+class TestToolsCommand:
+    """Tests for /tools command output."""
+
+    def test_tools_output_format(self):
+        """Tools command outputs correct format."""
+        # Create mock tools
+        mock_tool = MagicMock()
+        mock_tool.name = "ping_sweep"
+        mock_tool.description = (
+            "Scannt ein Netzwerk nach aktiven Hosts. Weitere Details."
+        )
+
+        mock_agent = MagicMock()
+        mock_agent.tools = [mock_tool]
+
+        output = StringIO()
+
+        # Simulate /tools command logic (from cli.py)
+        print("Available Tools:", file=output)
+        for tool in mock_agent.tools:
+            desc = tool.description
+            if ". " in desc:
+                desc = desc.split(". ")[0] + "."
+            elif len(desc) > 60:
+                desc = desc[:57] + "..."
+            print(f"  {tool.name} - {desc}", file=output)
+
+        result = output.getvalue()
+
+        assert "Available Tools:" in result
+        assert "ping_sweep" in result
+        # Description should be truncated to first sentence
+        assert "Scannt ein Netzwerk nach aktiven Hosts." in result
+        assert "Weitere Details" not in result
+
+    def test_tools_long_description_truncation(self):
+        """Long descriptions without periods are truncated with ellipsis."""
+        mock_tool = MagicMock()
+        mock_tool.name = "test_tool"
+        mock_tool.description = "A" * 100  # 100 chars, no period
+
+        mock_agent = MagicMock()
+        mock_agent.tools = [mock_tool]
+
+        output = StringIO()
+
+        print("Available Tools:", file=output)
+        for tool in mock_agent.tools:
+            desc = tool.description
+            if ". " in desc:
+                desc = desc.split(". ")[0] + "."
+            elif len(desc) > 60:
+                desc = desc[:57] + "..."
+            print(f"  {tool.name} - {desc}", file=output)
+
+        result = output.getvalue()
+
+        assert "test_tool" in result
+        assert "..." in result
+        # Should be truncated to 57 chars + "..."
+        assert len("A" * 57 + "...") == 60
+
+    def test_tools_multiple_tools(self):
+        """Multiple tools are listed."""
+        mock_tool1 = MagicMock()
+        mock_tool1.name = "tool_one"
+        mock_tool1.description = "First tool description."
+
+        mock_tool2 = MagicMock()
+        mock_tool2.name = "tool_two"
+        mock_tool2.description = "Second tool description."
+
+        mock_agent = MagicMock()
+        mock_agent.tools = [mock_tool1, mock_tool2]
+
+        output = StringIO()
+
+        print("Available Tools:", file=output)
+        for tool in mock_agent.tools:
+            desc = tool.description
+            if ". " in desc:
+                desc = desc.split(". ")[0] + "."
+            elif len(desc) > 60:
+                desc = desc[:57] + "..."
+            print(f"  {tool.name} - {desc}", file=output)
+
+        result = output.getvalue()
+
+        assert "tool_one" in result
+        assert "tool_two" in result
+
+
 class TestHelpCommand:
     """Tests for /help command."""
 
-    def test_help_includes_status(self):
-        """Help command lists /status."""
+    def test_help_includes_all_commands(self):
+        """Help command lists all commands including /tools."""
         output = StringIO()
 
-        # Simulate /help output (from cli.py:150-156)
+        # Simulate /help output (from cli.py)
         print("Commands:", file=output)
         print("  /help    - Show available commands", file=output)
+        print("  /tools   - List available tools", file=output)
         print("  /status  - Show session statistics", file=output)
         print("  /version - Show version", file=output)
         print("  /clear   - Reset session", file=output)
@@ -91,6 +184,7 @@ class TestHelpCommand:
 
         assert "/status" in result
         assert "/help" in result
+        assert "/tools" in result
         assert "/version" in result
         assert "/clear" in result
         assert "/exit" in result


### PR DESCRIPTION
## Summary
- Adds `/tools` command that lists all registered tools with name and description
- Updates `/help` to include the new command
- Descriptions are truncated to first sentence or 60 chars for readability

Closes #19

## Test plan
- [x] Unit tests for `/tools` output format
- [x] Unit tests for description truncation
- [x] Unit tests for multiple tools display
- [x] Manual Docker test verified output format
- [x] Local CI passed (lint, test, security, docker)

## Evidence
```
> /tools
Available Tools:
  ping_sweep - Scannt ein Netzwerk nach aktiven Hosts.

> /help
Commands:
  /help    - Show available commands
  /tools   - List available tools
  /status  - Show session statistics
  /version - Show version
  /clear   - Reset session
  /exit    - Quit
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)