### PR TITLE
feat: add DNS lookup tool (#24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-01-12
+
+### Added
+- **DNS Lookup Tool**: New `dns_lookup` tool for DNS queries - A, AAAA, MX, TXT, PTR, NS, SOA, CNAME, SRV records (#24)
+- **Auto-Detect Record Type**: IP addresses auto-detect to PTR, hostnames to A record
+- **Policy Exception**: DNS lookups allowed on public targets (query DNS servers, not scan targets)
+
 ## [0.3.7] - 2026-01-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Network Agent
 
-[![Version](https://img.shields.io/badge/version-0.3.7-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.4.0-blue.svg)](CHANGELOG.md)
 
 Ein KI-gesteuerter Netzwerk-Scanner. Statt komplizierte Terminal-Befehle zu lernen, stellst du einfach Fragen wie *"Welche Geräte sind in meinem Netzwerk?"* - der Agent erledigt den Rest.
 
@@ -195,13 +195,20 @@ Network Agent startet...
 - `Wer ist gerade online?` *(wenn du vorher ein Netzwerk gescannt hast)*
 - `Zeig mir alle aktiven Hosts in 10.0.0.0/24`
 
+**DNS-Abfragen:**
+- `Welche IP hat example.com?`
+- `Zeig mir die MX-Records von gmail.com`
+- `Reverse DNS für 8.8.8.8`
+- `Welcher Nameserver ist für heise.de zuständig?`
+
 **Folgefragen stellen:**
 - `Welche davon haben offene Ports?`
 - `Was läuft auf 192.168.1.10?`
 - `Gibt es Webserver im Netzwerk?`
 
 **Tipps:**
-- Du musst immer ein Netzwerk angeben (z.B. `192.168.1.0/24`)
+- Für Netzwerk-Scans brauchst du eine Netzwerk-Angabe (z.B. `192.168.1.0/24`)
+- DNS-Abfragen funktionieren mit jedem Hostnamen oder IP
 - Der Agent merkt sich vorherige Ergebnisse - du kannst Folgefragen stellen
 - Formuliere so, wie du einen Kollegen fragen würdest
 

--- a/cli.py
+++ b/cli.py
@@ -5,7 +5,7 @@ import yaml
 from pathlib import Path
 from dotenv import load_dotenv
 
-__version__ = "0.3.7"
+__version__ = "0.4.0"
 
 
 def truncate_description(desc: str, max_length: int = 60) -> str:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 openai>=1.0.0
 pyyaml>=6.0
 python-dotenv>=1.0.0
+dnspython>=2.4.0

--- a/tests/unit/test_dns_lookup.py
+++ b/tests/unit/test_dns_lookup.py
@@ -1,0 +1,158 @@
+"""Tests for tools/network/dns_lookup.py"""
+
+from unittest.mock import patch, MagicMock
+from tools.network.dns_lookup import DNSLookupTool
+
+
+class TestDNSLookupTool:
+    def setup_method(self):
+        self.tool = DNSLookupTool()
+
+    def test_name(self):
+        assert self.tool.name == "dns_lookup"
+
+    def test_description_mentions_dns(self):
+        assert "DNS" in self.tool.description
+
+    def test_parameters_has_target(self):
+        assert "target" in self.tool.parameters["properties"]
+        assert "target" in self.tool.parameters["required"]
+
+    def test_parameters_has_record_type(self):
+        assert "record_type" in self.tool.parameters["properties"]
+
+    @patch("tools.network.dns_lookup.dns.resolver.Resolver")
+    def test_a_record_lookup(self, mock_resolver_class):
+        mock_resolver = MagicMock()
+        mock_resolver_class.return_value = mock_resolver
+        mock_answer = MagicMock()
+        mock_answer.__str__ = lambda s: "93.184.216.34"
+        mock_resolver.resolve.return_value = [mock_answer]
+
+        result = self.tool.execute("example.com", "A")
+        assert "93.184.216.34" in result
+        assert "DNS Lookup" in result
+
+    def test_empty_target(self):
+        result = self.tool.execute("")
+        assert "Error" in result
+        assert "No target" in result
+
+    def test_whitespace_only_target(self):
+        result = self.tool.execute("   ")
+        assert "Error" in result
+
+    @patch("tools.network.dns_lookup.dns.resolver.Resolver")
+    def test_auto_detects_ptr_for_ip(self, mock_resolver_class):
+        mock_resolver = MagicMock()
+        mock_resolver_class.return_value = mock_resolver
+        mock_answer = MagicMock()
+        mock_answer.__str__ = lambda s: "dns.google."
+        mock_resolver.resolve.return_value = [mock_answer]
+
+        result = self.tool.execute("8.8.8.8", "auto")
+        # PTR lookup should be used for IP
+        assert "PTR" in result or "dns.google" in result
+
+    def test_ptr_guard_rejects_hostname_with_ptr(self):
+        """PTR lookup requires IP, not hostname."""
+        result = self.tool.execute("example.com", "PTR")
+        assert "Error" in result
+        assert "IP address" in result
+
+    def test_record_type_case_insensitive(self):
+        """Lowercase record types should work (LLMs send lowercase)."""
+        with patch("tools.network.dns_lookup.dns.resolver.Resolver") as mock:
+            mock_instance = MagicMock()
+            mock.return_value = mock_instance
+            mock_answer = MagicMock()
+            mock_answer.__str__ = lambda s: "10.0.0.1"
+            mock_instance.resolve.return_value = [mock_answer]
+
+            result = self.tool.execute("example.local", "a")  # lowercase!
+            assert "Invalid record type" not in result
+
+    def test_trailing_dot_normalized(self):
+        """FQDN trailing dot should be normalized."""
+        with patch("tools.network.dns_lookup.dns.resolver.Resolver") as mock:
+            mock_instance = MagicMock()
+            mock.return_value = mock_instance
+            mock_answer = MagicMock()
+            mock_answer.__str__ = lambda s: "10.0.0.1"
+            mock_instance.resolve.return_value = [mock_answer]
+
+            result = self.tool.execute("example.local.", "A")  # with trailing dot
+            mock_instance.resolve.assert_called()
+            # Should not fail
+            assert "Error" not in result or "Invalid" not in result
+
+    def test_invalid_record_type_rejected(self):
+        """Invalid record type should return error."""
+        result = self.tool.execute("example.com", "INVALID")
+        assert "Error" in result
+        assert "Invalid record type" in result
+
+    @patch("tools.network.dns_lookup.dns.resolver.Resolver")
+    def test_nxdomain_handled(self, mock_resolver_class):
+        """NXDOMAIN should return friendly error."""
+        import dns.resolver
+
+        mock_resolver = MagicMock()
+        mock_resolver_class.return_value = mock_resolver
+        mock_resolver.resolve.side_effect = dns.resolver.NXDOMAIN()
+
+        result = self.tool.execute("nonexistent.invalid", "A")
+        assert "Error" in result
+        assert "not found" in result
+
+    @patch("tools.network.dns_lookup.dns.resolver.Resolver")
+    def test_timeout_handled(self, mock_resolver_class):
+        """Timeout should return friendly error."""
+        import dns.resolver
+
+        mock_resolver = MagicMock()
+        mock_resolver_class.return_value = mock_resolver
+        mock_resolver.resolve.side_effect = dns.resolver.Timeout()
+
+        result = self.tool.execute("slow.example.com", "A")
+        assert "Error" in result
+        assert "timed out" in result
+
+
+class TestDNSLookupTypeGuards:
+    """Type guards for LLM input validation."""
+
+    def setup_method(self):
+        self.tool = DNSLookupTool()
+
+    def test_target_not_string_rejected(self):
+        result = self.tool.execute(target=123)
+        assert "Error" in result
+        assert "target must be string" in result
+
+    def test_record_type_not_string_rejected(self):
+        result = self.tool.execute(target="example.com", record_type=123)
+        assert "Error" in result
+        assert "record_type must be string" in result
+
+    def test_timeout_not_int_rejected(self):
+        result = self.tool.execute(target="example.com", timeout="10")
+        assert "Error" in result
+        assert "timeout must be integer" in result
+
+    def test_timeout_bool_rejected(self):
+        """Bool is int subclass, but should be rejected."""
+        result = self.tool.execute(target="example.com", timeout=True)
+        assert "Error" in result
+        assert "timeout must be integer" in result
+
+    def test_timeout_zero_rejected(self):
+        """timeout=0 should be rejected (>= 1 required)."""
+        result = self.tool.execute(target="example.com", timeout=0)
+        assert "Error" in result
+        assert ">= 1" in result
+
+    def test_timeout_negative_rejected(self):
+        """Negative timeout should be rejected."""
+        result = self.tool.execute(target="example.com", timeout=-5)
+        assert "Error" in result

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,9 +1,10 @@
 from tools.network.ping_sweep import PingSweepTool
+from tools.network.dns_lookup import DNSLookupTool
 
 
 def get_all_tools():
     """Registry: Alle verfügbaren Tools"""
     return [
         PingSweepTool(),
-        # Neue Tools hier hinzufügen
+        DNSLookupTool(),
     ]

--- a/tools/network/dns_lookup.py
+++ b/tools/network/dns_lookup.py
@@ -1,0 +1,132 @@
+"""DNS Lookup Tool - Exception to private-only policy."""
+
+import ipaddress
+import dns.resolver
+import dns.reversename
+from tools.base import BaseTool
+
+
+class DNSLookupTool(BaseTool):
+    RECORD_TYPES = ["A", "AAAA", "MX", "TXT", "PTR", "NS", "SOA", "CNAME", "SRV"]
+
+    @property
+    def name(self) -> str:
+        return "dns_lookup"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Performs DNS lookups. Supports A, AAAA, MX, TXT, PTR, NS, SOA, CNAME, SRV. "
+            "Unlike scan tools, DNS lookups are allowed on any target (public or private) "
+            "as they only query DNS servers, not the targets themselves."
+        )
+
+    @property
+    def parameters(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "target": {
+                    "type": "string",
+                    "description": "Hostname or IP address (public or private allowed)",
+                },
+                "record_type": {
+                    "type": "string",
+                    "enum": ["auto"] + self.RECORD_TYPES,
+                    "description": "DNS record type. 'auto': IP->PTR, hostname->A",
+                },
+                "timeout": {
+                    "type": "integer",
+                    "description": "Timeout in seconds (default: 10)",
+                },
+            },
+            "required": ["target"],
+        }
+
+    def execute(self, target: str, record_type: str = "auto", timeout: int = 10) -> str:
+        # Type-Guards (LLM can send wrong types!)
+        if not isinstance(target, str):
+            return f"Error: target must be string, got {type(target).__name__}"
+        if not isinstance(record_type, str):
+            return (
+                f"Error: record_type must be string, got {type(record_type).__name__}"
+            )
+        # timeout bool-check (bool is int subclass!)
+        if type(timeout) is not int:
+            return f"Error: timeout must be integer, got {type(timeout).__name__}"
+        # timeout >= 1 consistent with scan tools
+        if timeout < 1:
+            return f"Error: timeout must be >= 1, got {timeout}"
+
+        target = target.strip()
+        # Normalize FQDN trailing dot (example.com. -> example.com)
+        target = target.rstrip(".")
+        if not target:
+            return "Error: No target specified"
+
+        # Case-insensitive record types (LLMs often send lowercase)
+        if record_type != "auto":
+            record_type = record_type.upper()
+
+        # Record-type guard - validate before processing
+        valid_types = ["auto"] + self.RECORD_TYPES
+        if record_type not in valid_types:
+            return f"Error: Invalid record type '{record_type}'. Valid: {', '.join(self.RECORD_TYPES)}"
+
+        try:
+            # Auto-detect record type
+            is_ip = False
+            try:
+                ipaddress.ip_address(target)
+                is_ip = True
+            except ValueError:
+                pass
+
+            if record_type == "auto":
+                record_type = "PTR" if is_ip else "A"
+
+            # PTR-Guard - hostname + PTR is invalid
+            if record_type == "PTR" and not is_ip:
+                return (
+                    f"Error: PTR lookup requires an IP address, not hostname '{target}'. "
+                    "Use 'auto' for hostname lookups."
+                )
+
+            resolver = dns.resolver.Resolver()
+            resolver.timeout = timeout
+            resolver.lifetime = timeout
+
+            if record_type == "PTR":
+                rev_name = dns.reversename.from_address(target)
+                answers = resolver.resolve(rev_name, "PTR")
+            else:
+                answers = resolver.resolve(target, record_type)
+
+            results = [str(rdata) for rdata in answers]
+            return f"DNS Lookup: {target} ({record_type})\n" + "\n".join(
+                f"  {r}" for r in results
+            )
+
+        except dns.resolver.NXDOMAIN:
+            return f"Error: Domain not found: {target}"
+        except dns.resolver.NoAnswer:
+            return f"Error: No {record_type} records for {target}"
+        except dns.resolver.Timeout:
+            return f"Error: DNS lookup timed out after {timeout}s"
+        except Exception as e:
+            return f"Error: {e}"
+
+
+if __name__ == "__main__":
+    import sys
+
+    tool = DNSLookupTool()
+    if len(sys.argv) < 2:
+        print("Usage: python -m tools.network.dns_lookup <target> [record_type]")
+        sys.exit(1)
+    print(
+        tool.execute(
+            target=sys.argv[1],
+            record_type=sys.argv[2] if len(sys.argv) > 2 else "auto",
+        )
+    )


### PR DESCRIPTION
## Summary
- New `dns_lookup` tool for DNS record queries (A, AAAA, MX, TXT, PTR, NS, SOA, CNAME, SRV)
- Auto-detect record type: IP addresses → PTR, hostnames → A
- Policy exception: DNS lookups allowed on public targets (queries DNS servers, doesn't scan targets)
- Type guards for LLM input validation (target, record_type, timeout)
- 20 unit tests covering all functionality and edge cases
- Updated README with DNS query examples

## Changes
- `tools/network/dns_lookup.py` - New DNS lookup tool implementation
- `tools/__init__.py` - Registered DNSLookupTool in registry
- `tests/unit/test_dns_lookup.py` - 20 tests for DNS functionality
- `requirements.txt` - Added dnspython>=2.4.0
- `README.md` - Added DNS query examples, updated version badge
- `CHANGELOG.md` - Added 0.4.0 entry
- `cli.py` - Version bump to 0.4.0

## Test plan
- [x] 20 unit tests pass
- [x] All 145 tests pass
- [x] Local CI (act push) - all 4 jobs green
- [x] Docker build successful
- [x] Manual test: `python -m tools.network.dns_lookup example.com A` → returns IPs
- [x] Manual test: `python -m tools.network.dns_lookup 8.8.8.8 auto` → returns dns.google

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)