### PR TITLE
feat: add port scanner tool (#25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-01-12
+
+### Added
+- **Port Scanner Tool**: New `port_scanner` tool for TCP port scanning (#25)
+- **Flexible Port Specification**: Port lists (22,80,443) and ranges (1-1000), max 1000 ports
+- **Timing Templates**: T0 (slowest) to T5 (fastest) for scan speed control
+- **Skip Discovery**: `-Pn` flag support for hosts that block ping
+- **Configurable Defaults**: Default ports from config or --top-ports 100
+
 ## [0.4.0] - 2026-01-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Network Agent
 
-[![Version](https://img.shields.io/badge/version-0.4.0-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.5.0-blue.svg)](CHANGELOG.md)
 
 Ein KI-gesteuerter Netzwerk-Scanner. Statt komplizierte Terminal-Befehle zu lernen, stellst du einfach Fragen wie *"Welche Geräte sind in meinem Netzwerk?"* - der Agent erledigt den Rest.
 
@@ -200,6 +200,12 @@ Network Agent startet...
 - `Zeig mir die MX-Records von gmail.com`
 - `Reverse DNS für 8.8.8.8`
 - `Welcher Nameserver ist für heise.de zuständig?`
+
+**Port-Scans:**
+- `Scanne die Ports 22, 80, 443 auf 192.168.1.1`
+- `Welche Ports sind auf dem Router offen?`
+- `Prüfe Ports 1-1000 auf 192.168.1.10`
+- `Schneller Portscan auf 192.168.1.0/24` *(mit T4 Timing)*
 
 **Folgefragen stellen:**
 - `Welche davon haben offene Ports?`

--- a/cli.py
+++ b/cli.py
@@ -5,7 +5,7 @@ import yaml
 from pathlib import Path
 from dotenv import load_dotenv
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"
 
 
 def truncate_description(desc: str, max_length: int = 60) -> str:

--- a/tests/unit/test_port_scanner.py
+++ b/tests/unit/test_port_scanner.py
@@ -1,0 +1,212 @@
+"""Tests for tools/network/port_scanner.py"""
+
+from unittest.mock import patch, MagicMock
+import pytest
+from tools.network.port_scanner import PortScannerTool
+
+
+@pytest.fixture
+def mock_nmap_available():
+    """Mock nmap availability check."""
+    with patch("tools.network.port_scanner.require_nmap") as mock:
+        mock.return_value = (True, "")
+        yield mock
+
+
+class TestPortScannerTool:
+    def setup_method(self):
+        self.tool = PortScannerTool()
+
+    def test_name(self):
+        assert self.tool.name == "port_scanner"
+
+    def test_description_mentions_ports(self):
+        assert "port" in self.tool.description.lower()
+
+    def test_parameters_has_target(self):
+        assert "target" in self.tool.parameters["properties"]
+        assert "target" in self.tool.parameters["required"]
+
+    def test_parameters_has_ports(self):
+        assert "ports" in self.tool.parameters["properties"]
+
+    def test_parameters_has_timing(self):
+        assert "timing" in self.tool.parameters["properties"]
+        assert "enum" in self.tool.parameters["properties"]["timing"]
+
+    def test_parameters_has_skip_discovery(self):
+        assert "skip_discovery" in self.tool.parameters["properties"]
+
+    def test_empty_target_rejected(self, mock_nmap_available):
+        result = self.tool.execute("")
+        assert "Validation error" in result
+
+    def test_whitespace_only_target_rejected(self, mock_nmap_available):
+        result = self.tool.execute("   ")
+        assert "Validation error" in result
+
+    def test_public_ip_rejected(self, mock_nmap_available):
+        """Public IPs should be rejected."""
+        result = self.tool.execute("8.8.8.8")
+        assert "Validation error" in result
+        assert "Public IP" in result or "public" in result.lower()
+
+    def test_ipv6_rejected(self, mock_nmap_available):
+        """IPv6 should be rejected."""
+        result = self.tool.execute("::1")
+        assert "Validation error" in result
+        assert "IPv6" in result
+
+    def test_invalid_timing_rejected(self, mock_nmap_available):
+        """Invalid timing template should be rejected."""
+        result = self.tool.execute("192.168.1.1", timing="T99")
+        assert "Validation error" in result
+        assert "timing" in result.lower()
+
+    def test_timing_case_insensitive(self, mock_nmap_available):
+        """Lowercase timing should work."""
+        with patch("tools.network.port_scanner.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            result = self.tool.execute("127.0.0.1", timing="t3")
+            assert "Validation error" not in result
+
+    def test_invalid_ports_rejected(self, mock_nmap_available):
+        """Invalid port list should be rejected."""
+        result = self.tool.execute("127.0.0.1", ports="abc")
+        assert "Validation error" in result
+
+    def test_too_many_ports_rejected(self, mock_nmap_available):
+        """More than 1000 ports should be rejected."""
+        result = self.tool.execute("127.0.0.1", ports="1-1001")
+        assert "Validation error" in result
+        assert "Too many ports" in result
+
+    def test_port_range_valid(self, mock_nmap_available):
+        """Valid port range should work."""
+        with patch("tools.network.port_scanner.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            result = self.tool.execute("127.0.0.1", ports="1-1000")
+            assert "Validation error" not in result
+
+    def test_port_list_valid(self, mock_nmap_available):
+        """Valid port list should work."""
+        with patch("tools.network.port_scanner.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            result = self.tool.execute("127.0.0.1", ports="22,80,443")
+            assert "Validation error" not in result
+
+    @patch("tools.network.port_scanner.subprocess.run")
+    def test_successful_scan(self, mock_run, mock_nmap_available):
+        """Successful scan should return results."""
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="PORT   STATE SERVICE\n22/tcp open  ssh\n",
+            stderr="",
+        )
+        result = self.tool.execute("127.0.0.1", ports="22")
+        assert "Port Scan" in result
+        assert "22/tcp" in result or "PORT" in result
+
+    @patch("tools.network.port_scanner.subprocess.run")
+    def test_uses_tcp_connect_scan(self, mock_run, mock_nmap_available):
+        """Should use TCP Connect scan (-sT)."""
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        self.tool.execute("127.0.0.1", ports="22")
+        cmd = mock_run.call_args[0][0]
+        assert "-sT" in cmd
+
+    @patch("tools.network.port_scanner.subprocess.run")
+    def test_uses_no_dns_flag(self, mock_run, mock_nmap_available):
+        """Should use -n flag to prevent DNS leak."""
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        self.tool.execute("127.0.0.1", ports="22")
+        cmd = mock_run.call_args[0][0]
+        assert "-n" in cmd
+
+    @patch("tools.network.port_scanner.subprocess.run")
+    def test_skip_discovery_flag(self, mock_run, mock_nmap_available):
+        """skip_discovery should add -Pn flag."""
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        self.tool.execute("127.0.0.1", ports="22", skip_discovery=True)
+        cmd = mock_run.call_args[0][0]
+        assert "-Pn" in cmd
+
+    @patch("tools.network.port_scanner.subprocess.run")
+    def test_warning_pn_with_network(self, mock_run, mock_nmap_available):
+        """Warning when using -Pn with network range."""
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        result = self.tool.execute("127.0.0.0/30", ports="22", skip_discovery=True)
+        assert "Warning" in result
+        assert "-Pn" in result or "slow" in result.lower()
+
+    @patch("tools.network.port_scanner.subprocess.run")
+    @patch("tools.network.port_scanner.get_scan_config")
+    def test_default_top_ports(self, mock_get_config, mock_run, mock_nmap_available):
+        """Without ports param and no config ports, should use --top-ports."""
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        # Create mock config with no tcp_ports
+        mock_config = MagicMock()
+        mock_config.get_error.return_value = None
+        mock_config.tcp_ports = None
+        mock_config.max_hosts_portscan = 256
+        mock_config.exclude_ips = []
+        mock_config.timeout = 120
+        mock_get_config.return_value = mock_config
+        # Create new tool instance with mocked config
+        tool = PortScannerTool()
+        tool.execute("127.0.0.1")
+        cmd = mock_run.call_args[0][0]
+        assert "--top-ports" in cmd
+
+    def test_network_too_large_rejected(self, mock_nmap_available):
+        """Networks larger than /24 should be rejected."""
+        result = self.tool.execute("192.168.0.0/16")
+        assert "Validation error" in result
+        assert "too large" in result.lower() or "max" in result.lower()
+
+
+class TestPortScannerTypeGuards:
+    """Type guards for LLM input validation."""
+
+    def setup_method(self):
+        self.tool = PortScannerTool()
+
+    def test_target_not_string_rejected(self):
+        result = self.tool.execute(target=123)
+        assert "Validation error" in result
+        assert "target must be string" in result
+
+    def test_ports_not_string_rejected(self):
+        result = self.tool.execute(target="127.0.0.1", ports=123)
+        assert "Validation error" in result
+        assert "ports must be string" in result
+
+    def test_timing_not_string_rejected(self):
+        result = self.tool.execute(target="127.0.0.1", timing=3)
+        assert "Validation error" in result
+        assert "timing must be string" in result
+
+    def test_skip_discovery_not_bool_rejected(self):
+        result = self.tool.execute(target="127.0.0.1", skip_discovery="yes")
+        assert "Validation error" in result
+        assert "skip_discovery must be boolean" in result
+
+    def test_timeout_not_int_rejected(self):
+        result = self.tool.execute(target="127.0.0.1", timeout="60")
+        assert "Validation error" in result
+        assert "timeout must be integer" in result
+
+    def test_timeout_bool_rejected(self):
+        """Bool is int subclass, but should be rejected."""
+        result = self.tool.execute(target="127.0.0.1", timeout=True)
+        assert "Validation error" in result
+        assert "timeout must be integer" in result
+
+    def test_timeout_zero_rejected(self):
+        result = self.tool.execute(target="127.0.0.1", timeout=0)
+        assert "Validation error" in result
+        assert ">= 1" in result
+
+    def test_timeout_negative_rejected(self):
+        result = self.tool.execute(target="127.0.0.1", timeout=-5)
+        assert "Validation error" in result

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,5 +1,6 @@
 from tools.network.ping_sweep import PingSweepTool
 from tools.network.dns_lookup import DNSLookupTool
+from tools.network.port_scanner import PortScannerTool
 
 
 def get_all_tools():
@@ -7,4 +8,5 @@ def get_all_tools():
     return [
         PingSweepTool(),
         DNSLookupTool(),
+        PortScannerTool(),
     ]

--- a/tools/network/port_scanner.py
+++ b/tools/network/port_scanner.py
@@ -1,0 +1,260 @@
+"""Port Scanner Tool - TCP port scanning with nmap backend."""
+
+import subprocess
+from typing import List, Optional
+from tools.base import BaseTool
+from tools.validation import (
+    resolve_and_validate,
+    require_nmap,
+    validate_port_list,
+    count_ports,
+)
+from tools.config import get_scan_config
+
+
+class PortScannerTool(BaseTool):
+    # Valid timing templates (T0=paranoid to T5=insane)
+    TIMING_TEMPLATES = ["T0", "T1", "T2", "T3", "T4", "T5"]
+
+    def __init__(self):
+        super().__init__()
+        self._config = get_scan_config()
+
+    @property
+    def name(self) -> str:
+        return "port_scanner"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Scans TCP ports on target hosts. Supports single IPs, hostnames, "
+            "or networks (max /24). Use port lists (22,80,443) or ranges (1-1000). "
+            "Max 1000 ports per scan. Private networks only."
+        )
+
+    @property
+    def parameters(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "target": {
+                    "type": "string",
+                    "description": "IP address, hostname, or CIDR network (max /24)",
+                },
+                "ports": {
+                    "type": "string",
+                    "description": "Port list (22,80,443) or range (1-1000). Default: top 100 ports",
+                },
+                "timing": {
+                    "type": "string",
+                    "enum": self.TIMING_TEMPLATES,
+                    "description": "Scan speed: T0 (slowest) to T5 (fastest). Default: T3",
+                },
+                "skip_discovery": {
+                    "type": "boolean",
+                    "description": "Skip host discovery (-Pn). Use for hosts that block ping.",
+                },
+                "timeout": {
+                    "type": "integer",
+                    "description": "Timeout in seconds. Default: from config or 120",
+                },
+            },
+            "required": ["target"],
+        }
+
+    @property
+    def max_hosts(self) -> int:
+        """Use portscan limit (256 = /24), not discovery limit."""
+        return self._config.max_hosts_portscan
+
+    @property
+    def exclude_list(self) -> List[str]:
+        return self._config.exclude_ips
+
+    @property
+    def default_timeout(self) -> int:
+        return self._config.timeout
+
+    @property
+    def default_ports(self) -> Optional[str]:
+        """Get default ports from config, or None for --top-ports."""
+        return self._config.tcp_ports
+
+    def _validate_config_ports(self, ports: str) -> tuple[bool, str]:
+        """Validate config ports, return (valid, warning_if_invalid)."""
+        valid, error, _ = validate_port_list(ports)
+        if not valid:
+            return (
+                False,
+                f"Warning: Invalid config ports ({error}), using --top-ports 100",
+            )
+        return True, ""
+
+    def execute(
+        self,
+        target: str,
+        ports: str = None,
+        timing: str = "T3",
+        skip_discovery: bool = False,
+        timeout: int = None,
+    ) -> str:
+        """Execute port scan."""
+        warnings: List[str] = []
+
+        # === TYPE GUARDS (LLM can send wrong types!) ===
+        if not isinstance(target, str):
+            return (
+                f"Validation error: target must be string, got {type(target).__name__}"
+            )
+        if ports is not None and not isinstance(ports, str):
+            return f"Validation error: ports must be string, got {type(ports).__name__}"
+        if not isinstance(timing, str):
+            return (
+                f"Validation error: timing must be string, got {type(timing).__name__}"
+            )
+        # skip_discovery: bool check (bool is int subclass, but we accept both)
+        if not isinstance(skip_discovery, bool):
+            return f"Validation error: skip_discovery must be boolean, got {type(skip_discovery).__name__}"
+        # timeout: int check (exclude bool!)
+        if timeout is not None:
+            if type(timeout) is not int:
+                return f"Validation error: timeout must be integer, got {type(timeout).__name__}"
+            if timeout < 1:
+                return f"Validation error: timeout must be >= 1, got {timeout}"
+
+        # === CONFIG CHECK ===
+        if config_error := self._config.get_error():
+            return f"Validation error: {config_error}"
+
+        # === NMAP CHECK ===
+        nmap_ok, nmap_error = require_nmap()
+        if not nmap_ok:
+            return nmap_error
+
+        # === TIMING VALIDATION ===
+        timing = timing.upper()
+        if timing not in self.TIMING_TEMPLATES:
+            return f"Validation error: Invalid timing '{timing}'. Valid: {', '.join(self.TIMING_TEMPLATES)}"
+
+        # === TARGET VALIDATION ===
+        valid, error, targets = resolve_and_validate(
+            target,
+            allow_public=False,
+            max_hosts=self.max_hosts,
+            exclude_list=self.exclude_list,
+        )
+        if not valid:
+            return error
+
+        # Order-preserving dedup
+        targets = list(dict.fromkeys(targets))
+
+        # === PORT VALIDATION ===
+        use_top_ports = False
+        if ports is None:
+            # Try config default ports
+            config_ports = self.default_ports
+            if config_ports:
+                valid, warning = self._validate_config_ports(config_ports)
+                if valid:
+                    ports = config_ports
+                else:
+                    warnings.append(warning)
+                    use_top_ports = True
+            else:
+                use_top_ports = True
+        else:
+            # Validate user-provided ports
+            valid, error, normalized = validate_port_list(ports)
+            if not valid:
+                return error
+            ports = normalized
+
+        # === WARNINGS ===
+        # Warn if -Pn with network range (can be slow)
+        is_network = any("/" in t for t in targets)
+        if skip_discovery and is_network:
+            warnings.append(
+                "Warning: -Pn with network range can be slow (scans all IPs regardless of host status)"
+            )
+
+        # === BUILD NMAP COMMAND ===
+        # TCP Connect scan (-sT) doesn't require root
+        # -n: no DNS resolution (prevents DNS leak)
+        # --open: only show open ports
+        cmd = ["nmap", "-sT", "-n", "--open", f"-{timing}"]
+
+        if skip_discovery:
+            cmd.append("-Pn")
+
+        if use_top_ports:
+            cmd.extend(["--top-ports", "100"])
+        else:
+            cmd.extend(["-p", ports])
+
+        cmd.extend(targets)
+
+        # === EXECUTE ===
+        effective_timeout = timeout if timeout else self.default_timeout
+        target_info = f"{len(targets)} targets" if len(targets) > 1 else targets[0]
+        port_info = (
+            "--top-ports 100" if use_top_ports else f"{count_ports(ports)} ports"
+        )
+
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=effective_timeout,
+            )
+
+            # Build output with warnings first
+            output_parts = []
+            if warnings:
+                output_parts.extend(warnings)
+                output_parts.append("")  # Empty line after warnings
+
+            output_parts.append(f"[Port Scan: {target_info}]")
+            output_parts.append(f"[Ports: {port_info}] [Timing: {timing}]")
+            output_parts.append("")
+
+            if result.returncode == 0:
+                output_parts.append(result.stdout)
+            else:
+                output_parts.append(f"Error: {result.stderr}")
+
+            return "\n".join(output_parts)
+
+        except subprocess.TimeoutExpired:
+            # Include warnings even on timeout
+            output_parts = []
+            if warnings:
+                output_parts.extend(warnings)
+                output_parts.append("")
+            output_parts.append(
+                f"Error: Scan timeout (>{effective_timeout}s). Try fewer targets/ports or faster timing."
+            )
+            return "\n".join(output_parts)
+        except Exception as e:
+            output_parts = []
+            if warnings:
+                output_parts.extend(warnings)
+                output_parts.append("")
+            output_parts.append(f"Error: {e}")
+            return "\n".join(output_parts)
+
+
+if __name__ == "__main__":
+    import sys
+
+    tool = PortScannerTool()
+    if len(sys.argv) < 2:
+        print("Usage: python -m tools.network.port_scanner <target> [ports]")
+        sys.exit(1)
+    print(
+        tool.execute(
+            target=sys.argv[1],
+            ports=sys.argv[2] if len(sys.argv) > 2 else None,
+        )
+    )


### PR DESCRIPTION
## Summary
- New `port_scanner` tool for TCP port scanning on private networks
- Flexible port specification: lists (22,80,443) and ranges (1-1000)
- Timing templates T0-T5 for scan speed control
- Skip discovery (-Pn) option for hosts that block ping
- Default ports from config or --top-ports 100 fallback
- TCP Connect scan (-sT) - no root required

## Security
- Private networks only (RFC1918)
- IPv6 rejected
- No DNS leak (-n flag)
- Max 1000 ports per scan
- Max /24 network size

## Changes
- `tools/network/port_scanner.py` - New port scanner implementation
- `tools/__init__.py` - Registered PortScannerTool
- `tests/unit/test_port_scanner.py` - 31 tests
- `README.md` - Added port scan examples, version badge
- `CHANGELOG.md` - Added 0.5.0 entry
- `cli.py` - Version bump to 0.5.0

## Test plan
- [x] 31 unit tests pass
- [x] All 176 tests pass
- [x] Local CI (act push) - all 4 jobs green
- [x] Docker build successful

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)