### PR TITLE
feat: add service detection tool (#26)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-01-12
+
+### Added
+- **Service Detection Tool**: New `service_detect` tool to identify services and versions (#26)
+- **Version Probing**: Detects service names and versions (e.g., "OpenSSH 8.9", "Apache 2.4")
+- **Intensity Control**: Probe intensity 1-9 for balance between speed and accuracy
+- **Extended Timeout**: Default 300s timeout (service detection is slower than port scanning)
+
 ## [0.5.0] - 2026-01-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Network Agent
 
-[![Version](https://img.shields.io/badge/version-0.5.0-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.6.0-blue.svg)](CHANGELOG.md)
 
 Ein KI-gesteuerter Netzwerk-Scanner. Statt komplizierte Terminal-Befehle zu lernen, stellst du einfach Fragen wie *"Welche Geräte sind in meinem Netzwerk?"* - der Agent erledigt den Rest.
 
@@ -217,6 +217,18 @@ Network Agent startet...
 > - Du kannst einzelne Ports (`22,80,443`) oder Bereiche (`1-1000`) angeben
 > - "Schnell" oder "langsam" steuert die Scan-Geschwindigkeit
 > - Manche Geräte antworten nicht auf Ping - sag dann "auch wenn kein Ping"
+
+**Service-Erkennung:**
+- `Welche Services laufen auf 192.168.1.1?`
+- `Erkenne die Versionen auf dem Router`
+- `Was für ein Webserver läuft auf 192.168.1.10:80?`
+- `Gründliche Service-Erkennung auf 192.168.1.5` *(mit hoher Intensität)*
+
+> **Gut zu wissen:**
+> - Erkennt Service-Namen und Versionen (z.B. "OpenSSH 8.9", "Apache 2.4")
+> - Langsamer als Port-Scan, dafür mehr Details
+> - "Gründlich" oder "intensiv" für bessere Erkennung, "schnell" für oberflächlich
+> - Ohne Port-Angabe werden die 20 häufigsten Ports geprüft
 
 **Folgefragen stellen:**
 - `Welche davon haben offene Ports?`

--- a/cli.py
+++ b/cli.py
@@ -5,7 +5,7 @@ import yaml
 from pathlib import Path
 from dotenv import load_dotenv
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"
 
 
 def truncate_description(desc: str, max_length: int = 60) -> str:

--- a/tests/unit/test_service_detect.py
+++ b/tests/unit/test_service_detect.py
@@ -1,0 +1,171 @@
+"""Tests for tools/network/service_detect.py"""
+
+from unittest.mock import patch, MagicMock
+import pytest
+from tools.network.service_detect import ServiceDetectTool
+
+
+@pytest.fixture
+def mock_nmap_available():
+    """Mock nmap availability check."""
+    with patch("tools.network.service_detect.require_nmap") as mock:
+        mock.return_value = (True, "")
+        yield mock
+
+
+class TestServiceDetectTool:
+    def setup_method(self):
+        self.tool = ServiceDetectTool()
+
+    def test_name(self):
+        assert self.tool.name == "service_detect"
+
+    def test_description_mentions_service(self):
+        assert "service" in self.tool.description.lower()
+
+    def test_parameters_has_target(self):
+        assert "target" in self.tool.parameters["properties"]
+        assert "target" in self.tool.parameters["required"]
+
+    def test_parameters_has_ports(self):
+        assert "ports" in self.tool.parameters["properties"]
+
+    def test_parameters_has_intensity(self):
+        assert "intensity" in self.tool.parameters["properties"]
+
+    def test_parameters_has_skip_discovery(self):
+        assert "skip_discovery" in self.tool.parameters["properties"]
+
+    def test_empty_target_rejected(self, mock_nmap_available):
+        result = self.tool.execute("")
+        assert "Validation error" in result
+
+    def test_public_ip_rejected(self, mock_nmap_available):
+        result = self.tool.execute("8.8.8.8")
+        assert "Validation error" in result
+        assert "public" in result.lower() or "Public" in result
+
+    def test_ipv6_rejected(self, mock_nmap_available):
+        result = self.tool.execute("::1")
+        assert "Validation error" in result
+        assert "IPv6" in result
+
+    def test_intensity_too_low_rejected(self, mock_nmap_available):
+        result = self.tool.execute("127.0.0.1", intensity=0)
+        assert "Validation error" in result
+        assert "1-9" in result
+
+    def test_intensity_too_high_rejected(self, mock_nmap_available):
+        result = self.tool.execute("127.0.0.1", intensity=10)
+        assert "Validation error" in result
+        assert "1-9" in result
+
+    def test_intensity_valid_range(self, mock_nmap_available):
+        """Valid intensity values should work."""
+        with patch("tools.network.service_detect.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            for i in [1, 5, 9]:
+                result = self.tool.execute("127.0.0.1", intensity=i)
+                assert "Validation error" not in result
+
+    @patch("tools.network.service_detect.subprocess.run")
+    def test_uses_version_detection(self, mock_run, mock_nmap_available):
+        """Should use -sV flag for version detection."""
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        self.tool.execute("127.0.0.1")
+        cmd = mock_run.call_args[0][0]
+        assert "-sV" in cmd
+
+    @patch("tools.network.service_detect.subprocess.run")
+    def test_uses_version_intensity(self, mock_run, mock_nmap_available):
+        """Should use --version-intensity flag."""
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        self.tool.execute("127.0.0.1", intensity=7)
+        cmd = mock_run.call_args[0][0]
+        assert "--version-intensity=7" in cmd
+
+    @patch("tools.network.service_detect.subprocess.run")
+    def test_default_top_20_ports(self, mock_run, mock_nmap_available):
+        """Without ports param, should use --top-ports 20."""
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        self.tool.execute("127.0.0.1")
+        cmd = mock_run.call_args[0][0]
+        assert "--top-ports" in cmd
+        idx = cmd.index("--top-ports")
+        assert cmd[idx + 1] == "20"
+
+    @patch("tools.network.service_detect.subprocess.run")
+    def test_skip_discovery_flag(self, mock_run, mock_nmap_available):
+        """skip_discovery should add -Pn flag."""
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        self.tool.execute("127.0.0.1", skip_discovery=True)
+        cmd = mock_run.call_args[0][0]
+        assert "-Pn" in cmd
+
+    @patch("tools.network.service_detect.subprocess.run")
+    def test_warning_pn_with_network(self, mock_run, mock_nmap_available):
+        """Warning when using -Pn with network range."""
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        result = self.tool.execute("127.0.0.0/30", skip_discovery=True)
+        assert "Warning" in result
+
+    @patch("tools.network.service_detect.subprocess.run")
+    def test_successful_scan(self, mock_run, mock_nmap_available):
+        """Successful scan should return results."""
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="PORT   STATE SERVICE VERSION\n22/tcp open  ssh     OpenSSH 8.9\n",
+            stderr="",
+        )
+        result = self.tool.execute("127.0.0.1")
+        assert "Service Detection" in result
+        assert "OpenSSH" in result or "SERVICE" in result
+
+    def test_network_too_large_rejected(self, mock_nmap_available):
+        """Networks larger than /24 should be rejected."""
+        result = self.tool.execute("192.168.0.0/16")
+        assert "Validation error" in result
+
+
+class TestServiceDetectTypeGuards:
+    """Type guards for LLM input validation."""
+
+    def setup_method(self):
+        self.tool = ServiceDetectTool()
+
+    def test_target_not_string_rejected(self):
+        result = self.tool.execute(target=123)
+        assert "Validation error" in result
+        assert "target must be string" in result
+
+    def test_ports_not_string_rejected(self):
+        result = self.tool.execute(target="127.0.0.1", ports=80)
+        assert "Validation error" in result
+        assert "ports must be string" in result
+
+    def test_intensity_not_int_rejected(self):
+        result = self.tool.execute(target="127.0.0.1", intensity="5")
+        assert "Validation error" in result
+        assert "intensity must be integer" in result
+
+    def test_intensity_bool_rejected(self):
+        """Bool is int subclass, but should be rejected."""
+        result = self.tool.execute(target="127.0.0.1", intensity=True)
+        assert "Validation error" in result
+
+    def test_skip_discovery_not_bool_rejected(self):
+        result = self.tool.execute(target="127.0.0.1", skip_discovery="yes")
+        assert "Validation error" in result
+
+    def test_timeout_not_int_rejected(self):
+        result = self.tool.execute(target="127.0.0.1", timeout="300")
+        assert "Validation error" in result
+
+    def test_timeout_bool_rejected(self):
+        result = self.tool.execute(target="127.0.0.1", timeout=True)
+        assert "Validation error" in result
+
+    def test_timeout_zero_rejected(self):
+        result = self.tool.execute(target="127.0.0.1", timeout=0)
+        assert "Validation error" in result
+        assert ">= 1" in result

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,6 +1,7 @@
 from tools.network.ping_sweep import PingSweepTool
 from tools.network.dns_lookup import DNSLookupTool
 from tools.network.port_scanner import PortScannerTool
+from tools.network.service_detect import ServiceDetectTool
 
 
 def get_all_tools():
@@ -9,4 +10,5 @@ def get_all_tools():
         PingSweepTool(),
         DNSLookupTool(),
         PortScannerTool(),
+        ServiceDetectTool(),
     ]

--- a/tools/network/service_detect.py
+++ b/tools/network/service_detect.py
@@ -1,0 +1,218 @@
+"""Service Detection Tool - Identify services and versions on open ports."""
+
+import subprocess
+from typing import List
+from tools.base import BaseTool
+from tools.validation import (
+    resolve_and_validate,
+    require_nmap,
+    validate_port_list,
+)
+from tools.config import get_scan_config
+
+
+class ServiceDetectTool(BaseTool):
+    # Default timeout is longer for service detection (slow probes)
+    DEFAULT_TIMEOUT = 300
+
+    def __init__(self):
+        super().__init__()
+        self._config = get_scan_config()
+
+    @property
+    def name(self) -> str:
+        return "service_detect"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Detects services and versions running on open ports. "
+            "Slower than port_scanner but provides service names and versions. "
+            "Supports single IPs, hostnames, or networks (max /24). Private networks only."
+        )
+
+    @property
+    def parameters(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "target": {
+                    "type": "string",
+                    "description": "IP address, hostname, or CIDR network (max /24)",
+                },
+                "ports": {
+                    "type": "string",
+                    "description": "Port list (22,80,443) or range. Default: top 20 ports",
+                },
+                "intensity": {
+                    "type": "integer",
+                    "description": "Probe intensity 1-9 (higher = more probes, slower). Default: 5",
+                },
+                "skip_discovery": {
+                    "type": "boolean",
+                    "description": "Skip host discovery (-Pn). Use for hosts that block ping.",
+                },
+                "timeout": {
+                    "type": "integer",
+                    "description": "Timeout in seconds. Default: 300 (service detection is slow)",
+                },
+            },
+            "required": ["target"],
+        }
+
+    @property
+    def max_hosts(self) -> int:
+        return self._config.max_hosts_portscan
+
+    @property
+    def exclude_list(self) -> List[str]:
+        return self._config.exclude_ips
+
+    def execute(
+        self,
+        target: str,
+        ports: str = None,
+        intensity: int = 5,
+        skip_discovery: bool = False,
+        timeout: int = None,
+    ) -> str:
+        """Execute service detection scan."""
+        warnings: List[str] = []
+
+        # === TYPE GUARDS ===
+        if not isinstance(target, str):
+            return (
+                f"Validation error: target must be string, got {type(target).__name__}"
+            )
+        if ports is not None and not isinstance(ports, str):
+            return f"Validation error: ports must be string, got {type(ports).__name__}"
+        # intensity: int check (exclude bool!)
+        if type(intensity) is not int:
+            return f"Validation error: intensity must be integer, got {type(intensity).__name__}"
+        if not 1 <= intensity <= 9:
+            return f"Validation error: intensity must be 1-9, got {intensity}"
+        if not isinstance(skip_discovery, bool):
+            return f"Validation error: skip_discovery must be boolean, got {type(skip_discovery).__name__}"
+        if timeout is not None:
+            if type(timeout) is not int:
+                return f"Validation error: timeout must be integer, got {type(timeout).__name__}"
+            if timeout < 1:
+                return f"Validation error: timeout must be >= 1, got {timeout}"
+
+        # === CONFIG CHECK ===
+        if config_error := self._config.get_error():
+            return f"Validation error: {config_error}"
+
+        # === NMAP CHECK ===
+        nmap_ok, nmap_error = require_nmap()
+        if not nmap_ok:
+            return nmap_error
+
+        # === TARGET VALIDATION ===
+        valid, error, targets = resolve_and_validate(
+            target,
+            allow_public=False,
+            max_hosts=self.max_hosts,
+            exclude_list=self.exclude_list,
+        )
+        if not valid:
+            return error
+
+        # Order-preserving dedup
+        targets = list(dict.fromkeys(targets))
+
+        # === PORT VALIDATION ===
+        use_top_ports = False
+        if ports is None:
+            use_top_ports = True
+        else:
+            valid, error, normalized = validate_port_list(ports)
+            if not valid:
+                return error
+            ports = normalized
+
+        # === WARNINGS ===
+        is_network = any("/" in t for t in targets)
+        if skip_discovery and is_network:
+            warnings.append(
+                "Warning: -Pn with network range can be very slow for service detection"
+            )
+
+        # === BUILD NMAP COMMAND ===
+        # -sV: Version detection
+        # -sT: TCP Connect (no root needed)
+        # -n: No DNS resolution
+        # --open: Only show open ports
+        cmd = ["nmap", "-sT", "-sV", "-n", "--open"]
+        cmd.append(f"--version-intensity={intensity}")
+
+        if skip_discovery:
+            cmd.append("-Pn")
+
+        if use_top_ports:
+            cmd.extend(["--top-ports", "20"])
+        else:
+            cmd.extend(["-p", ports])
+
+        cmd.extend(targets)
+
+        # === EXECUTE ===
+        effective_timeout = timeout if timeout else self.DEFAULT_TIMEOUT
+        target_info = f"{len(targets)} targets" if len(targets) > 1 else targets[0]
+        port_info = "--top-ports 20" if use_top_ports else f"ports {ports}"
+
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=effective_timeout,
+            )
+
+            output_parts = []
+            if warnings:
+                output_parts.extend(warnings)
+                output_parts.append("")
+
+            output_parts.append(f"[Service Detection: {target_info}]")
+            output_parts.append(f"[{port_info}] [Intensity: {intensity}]")
+            output_parts.append("")
+
+            if result.returncode == 0:
+                output_parts.append(result.stdout)
+            else:
+                output_parts.append(f"Error: {result.stderr}")
+
+            return "\n".join(output_parts)
+
+        except subprocess.TimeoutExpired:
+            output_parts = []
+            if warnings:
+                output_parts.extend(warnings)
+                output_parts.append("")
+            output_parts.append(
+                f"Error: Scan timeout (>{effective_timeout}s). Service detection is slow - try fewer targets or lower intensity."
+            )
+            return "\n".join(output_parts)
+        except Exception as e:
+            output_parts = []
+            if warnings:
+                output_parts.extend(warnings)
+                output_parts.append("")
+            output_parts.append(f"Error: {e}")
+            return "\n".join(output_parts)
+
+
+if __name__ == "__main__":
+    import sys
+
+    tool = ServiceDetectTool()
+    if len(sys.argv) < 2:
+        print("Usage: python -m tools.network.service_detect <target> [ports]")
+        sys.exit(1)
+    print(
+        tool.execute(
+            target=sys.argv[1],
+            ports=sys.argv[2] if len(sys.argv) > 2 else None,
+        )
+    )


### PR DESCRIPTION
## Summary
- New `service_detect` tool for identifying services and versions on open ports
- Uses nmap `-sV` for version detection
- Intensity control 1-9 (higher = more probes, better detection, slower)
- Default: top 20 ports (service detection is slow)
- Extended timeout: 300s default

## Changes
- `tools/network/service_detect.py` - New service detection implementation
- `tools/__init__.py` - Registered ServiceDetectTool
- `tests/unit/test_service_detect.py` - 27 tests
- `README.md` - Added examples with "Gut zu wissen" block
- `CHANGELOG.md` - Added 0.6.0 entry
- `cli.py` - Version bump to 0.6.0

## Test plan
- [x] 27 unit tests pass
- [x] All 203 tests pass
- [x] Local CI (act push) - all 4 jobs green

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)