### PR TITLE
docs: switch to English messages and add documentation (#27)

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,0 +1,81 @@
+name: Auto Label
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  label-issues:
+    if: github.event_name == 'issues'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const title = context.payload.issue.title.toLowerCase();
+            const labels = ['status:backlog'];
+
+            // Type detection from title prefix
+            if (title.includes('[bug]') || title.startsWith('bug:') || title.startsWith('fix:')) {
+              labels.push('type:bug', 'priority:high');
+            } else if (title.includes('[feature]') || title.startsWith('feat:')) {
+              labels.push('type:feature');
+            } else if (title.includes('[docs]') || title.startsWith('docs:')) {
+              labels.push('type:docs');
+            } else if (title.includes('[refactor]') || title.startsWith('refactor:')) {
+              labels.push('type:refactor');
+            } else if (title.includes('[ci]') || title.startsWith('ci:')) {
+              labels.push('type:ci');
+            }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: labels
+            });
+
+  label-prs:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const title = context.payload.pull_request.title.toLowerCase();
+            const labels = [];
+
+            // Type detection from Conventional Commit prefix
+            if (title.startsWith('feat:') || title.startsWith('feat(')) {
+              labels.push('type:feature');
+            } else if (title.startsWith('fix:') || title.startsWith('fix(')) {
+              labels.push('type:bug');
+            } else if (title.startsWith('docs:') || title.startsWith('docs(')) {
+              labels.push('type:docs');
+            } else if (title.startsWith('refactor:') || title.startsWith('refactor(')) {
+              labels.push('type:refactor');
+            } else if (title.startsWith('ci:') || title.startsWith('ci(')) {
+              labels.push('type:ci');
+            } else if (title.startsWith('deps:') || title.startsWith('chore(deps)')) {
+              labels.push('type:deps');
+            }
+
+            // Dependabot PRs
+            if (context.payload.pull_request.user.login === 'dependabot[bot]') {
+              labels.push('type:deps');
+            }
+
+            if (labels.length > 0) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels: labels
+              });
+            }

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,0 +1,36 @@
+name: PR Lint
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  conventional-commits:
+    # Soft enforcement - NOT a required check (Dependabot compatibility)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR title follows Conventional Commits
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+            deps
+          requireScope: false
+          # Allow Dependabot titles like "Bump X from Y to Z"
+          ignoreLabels: |
+            type:deps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2026-01-12
+
+### Changed
+- **English Messages**: All CLI messages, docstrings, and system prompt switched to English (#27)
+- **Breaking Change**: Users wanting German responses should add `Always respond in German.` to system.md
+
+### Added
+- **Technical Documentation**: README now includes host limits, port defaults, IPv6 status
+- **DNS Exception**: Documented that dns_lookup can query public domains
+- **skip_discovery Guide**: Documented when to use -Pn flag and its risks
+
 ## [0.6.0] - 2026-01-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,8 +1,19 @@
 # Network Agent
 
-[![Version](https://img.shields.io/badge/version-0.6.0-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.7.0-blue.svg)](CHANGELOG.md)
 
 Ein KI-gesteuerter Netzwerk-Scanner. Statt komplizierte Terminal-Befehle zu lernen, stellst du einfach Fragen wie *"Welche Geräte sind in meinem Netzwerk?"* - der Agent erledigt den Rest.
+
+## Breaking Change in v0.7.0
+
+> **Ab Version 0.7.0** sind alle CLI-Meldungen und der System-Prompt auf Englisch umgestellt.
+>
+> **Warum?** Das Projekt ist auf GitHub öffentlich und soll international nutzbar sein.
+>
+> **Du willst deutsche Antworten?** Füge am Ende von `config/prompts/system.md` hinzu:
+> ```
+> Always respond in German (Deutsch).
+> ```
 
 ## Was macht dieses Tool?
 
@@ -178,11 +189,10 @@ docker run -it --rm --env-file .env network-agent:latest
 
 Nach dem Start siehst du:
 ```
-Network Agent startet...
+Network Agent starting...
    Model: gpt-4
+   Context limit: 8,192 tokens
    Type /help for available commands
-
-   Context-Limit: 8,192 tokens
 
 >
 ```
@@ -278,6 +288,40 @@ Der Network Agent ist für **lokale Netzwerk-Analyse** konzipiert:
 
 **Du willst trotzdem ein bestimmtes Netzwerk scannen?**
 Konfiguriere Ausnahmen in `config/settings.yaml` (siehe Scan-Einstellungen oben).
+
+<details>
+<summary><strong>Technische Details zu den Tools</strong></summary>
+
+### Host-Limits
+
+| Tool | Max Hosts | Netzwerk | Grund |
+|------|-----------|----------|-------|
+| ping_sweep | 65.536 | /16 | Schnell: 1 Probe pro Host |
+| port_scanner | 256 | /24 | Langsam: viele Probes pro Port |
+| service_detect | 256 | /24 | Sehr langsam: mehrere Probes pro Service |
+| dns_lookup | 1 | Einzeln | DNS-Abfragen sind immer einzeln |
+
+**Warum der Unterschied?** Discovery (ping_sweep) sendet nur einen Probe pro Host und ist deshalb schnell. Port- und Service-Scans senden viele Probes pro Host und würden bei großen Netzwerken sehr lange dauern.
+
+### Port-Defaults
+
+| Tool | Default Ports | Konfigurierbar? |
+|------|---------------|-----------------|
+| ping_sweep | 22, 80, 443, 8080 | Nein (fest) |
+| port_scanner | Top 100 | Ja (`ports` Parameter) |
+| service_detect | Top 20 | Ja (`ports` Parameter) |
+
+### IPv6 Support
+
+**Status:** Nicht unterstützt (nicht geplant)
+
+Alle Tools lehnen IPv6-Adressen ab (z.B. `::1`, `fe80::1`, `2001:db8::1`). Der Fokus liegt auf IPv4 Heimnetzwerken.
+
+### DNS Lookup Exception
+
+Das `dns_lookup` Tool ist das einzige Tool, das öffentliche Domains abfragen darf. Das ist bewusst so, weil DNS-Abfragen keine Scans sind - sie fragen nur DNS-Server ab.
+
+</details>
 
 ## Aktualisieren
 

--- a/cli.py
+++ b/cli.py
@@ -5,18 +5,18 @@ import yaml
 from pathlib import Path
 from dotenv import load_dotenv
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"
 
 
 def truncate_description(desc: str, max_length: int = 60) -> str:
-    """Kürzt eine Beschreibung auf den ersten Satz oder max_length Zeichen.
+    """Truncate description to first sentence or max_length characters.
 
     Args:
-        desc: Die zu kürzende Beschreibung
-        max_length: Maximale Länge (default: 60)
+        desc: Description to truncate
+        max_length: Maximum length (default: 60)
 
     Returns:
-        Gekürzte Beschreibung
+        Truncated description
     """
     if not desc:
         return ""
@@ -28,7 +28,7 @@ def truncate_description(desc: str, max_length: int = 60) -> str:
 
 
 def get_help_text() -> str:
-    """Gibt den Hilfetext für alle Commands zurück."""
+    """Return help text for all commands."""
     return """Commands:
   /help    - Show available commands
   /tools   - List available tools
@@ -40,7 +40,7 @@ def get_help_text() -> str:
 
 
 def get_tools_text() -> str:
-    """Gibt die Liste aller Tools zurück (ohne Agent-Initialisierung)."""
+    """Return list of all tools (without agent initialization)."""
     from tools import get_all_tools
 
     lines = ["Available Tools:"]
@@ -51,19 +51,19 @@ def get_tools_text() -> str:
 
 
 def check_setup() -> tuple[bool, list[str]]:
-    """Prüft ob alle erforderlichen Konfigurationen vorhanden sind.
+    """Check if all required configurations are present.
 
     Returns:
         (is_configured, missing_items)
     """
     missing = []
 
-    # Config laden
+    # Load config
     config_path = Path("config/settings.yaml")
     config = yaml.safe_load(config_path.read_text())
     provider = config.get("llm", {}).get("provider", {})
 
-    # Pflichtfelder prüfen
+    # Check required fields
     if not provider.get("model"):
         missing.append("model in config/settings.yaml")
     if not provider.get("base_url"):
@@ -75,46 +75,46 @@ def check_setup() -> tuple[bool, list[str]]:
 
 
 def show_setup_guide(missing: list[str]):
-    """Zeigt Setup-Anleitung für fehlende Konfiguration."""
+    """Show setup guide for missing configuration."""
     print("=" * 60)
-    print("Network Agent - Setup erforderlich")
+    print("Network Agent - Setup Required")
     print("=" * 60)
     print()
-    print("Folgende Konfiguration fehlt:")
+    print("Missing configuration:")
     for item in missing:
         print(f"  - {item}")
     print()
     print("-" * 60)
-    print("SETUP-ANLEITUNG:")
+    print("SETUP GUIDE:")
     print("-" * 60)
     print()
-    print("1. API Key einrichten:")
+    print("1. Set up API key:")
     print("   cp .env.example .env")
-    print("   # Dann .env bearbeiten und Key eintragen:")
-    print("   LLM_API_KEY=dein_api_key_hier")
+    print("   # Then edit .env and add your key:")
+    print("   LLM_API_KEY=your_api_key_here")
     print()
-    print("2. Provider konfigurieren (config/settings.yaml):")
+    print("2. Configure provider (config/settings.yaml):")
     print()
-    print("   Für OpenAI:")
+    print("   For OpenAI:")
     print('     model: "gpt-4"')
     print('     base_url: "https://api.openai.com/v1"')
     print()
-    print("   Für Groq (kostenlos):")
+    print("   For Groq (free):")
     print('     model: "llama-3.3-70b-versatile"')
     print('     base_url: "https://api.groq.com/openai/v1"')
     print()
-    print("   Für Ollama (lokal):")
+    print("   For Ollama (local):")
     print('     model: "llama3"')
     print('     base_url: "http://localhost:11434/v1"')
     print()
-    print("Mehr Provider: siehe README.md")
+    print("More providers: see README.md")
     print("=" * 60)
 
 
 def main():
     # Argument parsing
     parser = argparse.ArgumentParser(
-        description="Network Agent - KI-gesteuerter Netzwerk-Scanner"
+        description="Network Agent - AI-powered network scanner"
     )
     parser.add_argument(
         "--version", "-v", action="version", version=f"Network Agent v{__version__}"
@@ -127,7 +127,7 @@ def main():
     )
     args = parser.parse_args()
 
-    # Commands die OHNE LLM-Setup funktionieren
+    # Commands that work WITHOUT LLM setup
     if args.help_commands:
         print(get_help_text())
         sys.exit(0)
@@ -139,13 +139,13 @@ def main():
     # Load environment variables
     load_dotenv()
 
-    # Setup-Check (nur für interaktiven Modus)
+    # Setup check (only for interactive mode)
     is_configured, missing = check_setup()
     if not is_configured:
         show_setup_guide(missing)
         sys.exit(1)
 
-    # Ab hier: Alles konfiguriert, Agent starten
+    # From here: All configured, start agent
     from agent.core import NetworkAgent
 
     # Load config
@@ -157,13 +157,13 @@ def main():
     system_prompt = system_prompt_path.read_text()
 
     # Initialize agent
-    print("Network Agent startet...")
+    print("Network Agent starting...")
     print(f"   Model: {config['llm']['provider']['model']}")
 
     agent = NetworkAgent(config, system_prompt)
 
-    # Context-Limit anzeigen
-    print(f"   Context-Limit: {agent.context_limit:,} tokens")
+    # Show context limit
+    print(f"   Context limit: {agent.context_limit:,} tokens")
     print("   Type /help for available commands\n")
 
     # REPL Loop
@@ -185,7 +185,7 @@ def main():
 
                 if cmd == "/clear":
                     agent.clear_session()
-                    print("[Session zurückgesetzt]")
+                    print("[Session reset]")
                     continue
 
                 if cmd == "/version":
@@ -227,7 +227,7 @@ def main():
             response = agent.run(user_input)
             print(f"\n{response}")
 
-            # Token usage anzeigen
+            # Show token usage
             if agent.last_usage:
                 pct = agent.context_usage_percent
                 limit = agent.context_limit

--- a/config/prompts/system.md
+++ b/config/prompts/system.md
@@ -1,19 +1,86 @@
-Du bist ein Netzwerk-Analyse-Agent.
+# Network Analysis Agent
 
-## Verfügbare Tools
+You are a network analysis agent with access to specialized scanning tools.
 
-- **ping_sweep**: Scannt ein Netzwerk (CIDR) nach aktiven Hosts
+## Available Tools
 
-## Regeln
+### ping_sweep
+Discovers active hosts in a network using ICMP/TCP ping.
+- **Input**: CIDR network (e.g., `192.168.1.0/24`)
+- **Default**: Scans common ports (22, 80, 443, 8080) for TCP discovery
+- **Limit**: Max 65,536 hosts (up to /16 network)
 
-- Interpretiere nmap-Output für den User
-- Nutze nur erlaubte Netzwerke (private IPs)
-- Antworte auf Deutsch
-- Bei Fehlern: Erkläre was schiefging
+### dns_lookup
+Performs DNS queries for various record types.
+- **Input**: Hostname or IP address
+- **Types**: A, AAAA, MX, TXT, PTR, NS, SOA, CNAME, SRV
+- **Note**: This tool CAN query public domains (exception to private-only policy)
+- **Auto-detect**: IP addresses default to PTR (reverse DNS), hostnames to A record
 
-## Beispiel
+### port_scanner
+Scans TCP ports on target hosts.
+- **Input**: IP, hostname, or CIDR (max /24 = 256 hosts)
+- **Ports**: List (22,80,443), range (1-1000), or default (top 100)
+- **Timing**: T0 (slowest) to T5 (fastest), default T3
+- **Option**: `skip_discovery` (-Pn) for hosts that block ping
 
-User: "Welche Geräte sind im Netzwerk 192.168.1.0/24?"
-Du: [Tool: ping_sweep mit network=192.168.1.0/24]
-Output: [nmap results]
-Du: "Ich habe 5 aktive Geräte gefunden: ..."
+### service_detect
+Identifies services and versions on open ports.
+- **Input**: IP, hostname, or CIDR (max /24 = 256 hosts)
+- **Ports**: Default top 20 (slower than port_scanner)
+- **Intensity**: 1-9 (higher = more probes, better detection, slower)
+- **Option**: `skip_discovery` (-Pn) for hosts that block ping
+
+## Security Policies
+
+### Private Networks Only
+All scanning tools (except dns_lookup) only work on private IP ranges:
+- `10.0.0.0/8`
+- `172.16.0.0/12`
+- `192.168.0.0/16`
+- `127.0.0.0/8` (loopback, for local testing)
+
+Hostnames are resolved first - if they resolve to a public IP, they are blocked.
+
+### IPv6
+Not supported. All tools reject IPv6 addresses (e.g., `::1`, `fe80::1`).
+
+### Host Limits
+- **Discovery** (ping_sweep): Up to 65,536 hosts (/16 network)
+- **Port scanning** (port_scanner, service_detect): Up to 256 hosts (/24 network)
+
+This difference exists because discovery is fast (one probe per host), while port scanning is slow (many probes per host per port).
+
+## When to Use skip_discovery (-Pn)
+
+The `skip_discovery` option skips the initial ping check and scans all targets directly.
+
+**Use when:**
+- Target blocks ICMP ping (firewalls, hardened hosts)
+- You know the host is up but ping_sweep shows nothing
+- Scanning a single known-good IP
+
+**Avoid when:**
+- Scanning large networks (very slow without discovery)
+- You're not sure if hosts exist (wastes time on empty IPs)
+
+## Response Guidelines
+
+1. **Interpret results** for the user - don't just show raw nmap output
+2. **Summarize findings** (e.g., "Found 5 active hosts, 3 with open SSH")
+3. **Explain errors** clearly when scans fail
+4. **Suggest next steps** (e.g., "Want me to check what services are running?")
+
+## Example Interactions
+
+**User**: "What devices are on my network 192.168.1.0/24?"
+**You**: Use ping_sweep, then summarize: "I found 8 active devices: 192.168.1.1 (likely router), 192.168.1.100-105 (6 hosts), and 192.168.1.200."
+
+**User**: "Check if port 22 is open on 192.168.1.100"
+**You**: Use port_scanner with ports="22", report result.
+
+**User**: "What's running on 192.168.1.1?"
+**You**: Use service_detect, report services with versions (e.g., "OpenSSH 8.9, nginx 1.24").
+
+**User**: "What mail servers does example.com use?"
+**You**: Use dns_lookup with type="MX", explain the results.

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -5,7 +5,7 @@ from tools.network.service_detect import ServiceDetectTool
 
 
 def get_all_tools():
-    """Registry: Alle verfügbaren Tools"""
+    """Registry: All available tools."""
     return [
         PingSweepTool(),
         DNSLookupTool(),

--- a/tools/base.py
+++ b/tools/base.py
@@ -3,33 +3,33 @@ from typing import Dict, Any
 
 
 class BaseTool(ABC):
-    """Basis-Klasse für alle Tools"""
+    """Base class for all tools."""
 
     @property
     @abstractmethod
     def name(self) -> str:
-        """Tool-Name für LLM"""
+        """Tool name for LLM."""
         pass
 
     @property
     @abstractmethod
     def description(self) -> str:
-        """Tool-Beschreibung für LLM"""
+        """Tool description for LLM."""
         pass
 
     @property
     @abstractmethod
     def parameters(self) -> Dict[str, Any]:
-        """JSON Schema für Tool-Parameter"""
+        """JSON Schema for tool parameters."""
         pass
 
     @abstractmethod
     def execute(self, **kwargs) -> str:
-        """Tool ausführen, gibt String zurück"""
+        """Execute tool, returns string."""
         pass
 
     def to_openai_format(self) -> Dict[str, Any]:
-        """Konvertiert zu OpenAI Function Calling Format"""
+        """Convert to OpenAI Function Calling format."""
         return {
             "type": "function",
             "function": {


### PR DESCRIPTION
## Summary
- Switch all CLI messages, docstrings, and system prompt to English (breaking change)
- Add technical documentation section to README (host limits, port defaults, IPv6 status)
- Document DNS lookup exception and skip_discovery usage

## Breaking Change
Users wanting German LLM responses can add `Always respond in German.` to `config/prompts/system.md`

## Changes
- `cli.py`: All messages in English
- `tools/base.py`, `tools/__init__.py`: English docstrings
- `config/prompts/system.md`: Complete rewrite with all 4 tools documented
- `README.md`: Technical details, breaking change notice, German restoration guide
- Version bump to 0.7.0

## Test plan
- [x] All 203 tests pass
- [x] Local CI (lint, test, security, docker) all pass
- [ ] GitHub Actions CI

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)