### PR TITLE
ci: implement layered appliance build system

### DIFF
--- a/.github/workflows/appliance-build.yml
+++ b/.github/workflows/appliance-build.yml
@@ -7,6 +7,10 @@ on:
         description: 'Version (e.g., 0.4.0)'
         required: true
         type: string
+      base_version:
+        description: 'Base image version (e.g., 2026-01, or "latest")'
+        type: string
+        default: 'latest'
       skip_test:
         description: 'Skip E2E test (for debugging)'
         type: boolean
@@ -50,9 +54,13 @@ jobs:
         working-directory: infrastructure/packer
         run: packer init .
 
-      - name: Validate Packer template
+      - name: Validate Packer templates
         working-directory: infrastructure/packer
-        run: packer validate network-agent.pkr.hcl
+        run: |
+          # Validate layer template (used for release builds)
+          packer validate -var "version=0.0.0" -var "base_image=dummy.qcow2" layer.pkr.hcl
+          # Validate base template (used for monthly builds)
+          packer validate -var "base_version=2026-01" base.pkr.hcl
 
       - name: Validate docker-compose files
         run: |
@@ -144,18 +152,53 @@ jobs:
         run: packer init .
 
       # ═══════════════════════════════════════════════════════════
-      # BUILD PHASE
+      # BUILD PHASE (Layered: download base → build layer)
       # ═══════════════════════════════════════════════════════════
 
-      - name: Build qcow2 Image
+      - name: Download base image from MinIO
+        env:
+          MINIO_ENDPOINT: ${{ secrets.MINIO_ENDPOINT }}
+          MINIO_ACCESS_KEY: ${{ secrets.MINIO_ACCESS_KEY }}
+          MINIO_SECRET_KEY: ${{ secrets.MINIO_SECRET_KEY }}
+          BASE_VERSION: ${{ inputs.base_version || 'latest' }}
+        run: |
+          # Install mc client
+          wget -q https://dl.min.io/client/mc/release/linux-amd64/mc -O /tmp/mc
+          chmod +x /tmp/mc
+
+          # Configure alias
+          /tmp/mc alias set minio $MINIO_ENDPOINT $MINIO_ACCESS_KEY $MINIO_SECRET_KEY
+
+          # Create input directory
+          mkdir -p infrastructure/packer/input
+
+          # Download base image
+          BASE_FILE="base-${BASE_VERSION}.qcow2.zst"
+          echo "Downloading base image: $BASE_FILE"
+          /tmp/mc cp minio/appliance-base/${BASE_FILE} infrastructure/packer/input/
+
+          # Decompress base image
+          echo "Decompressing base image..."
+          cd infrastructure/packer/input
+          zstd -d -v ${BASE_FILE}
+          rm -f ${BASE_FILE}
+
+          # Rename to expected name
+          mv base-*.qcow2 base.qcow2
+          ls -lh base.qcow2
+          echo "BASE_IMAGE=input/base.qcow2" >> $GITHUB_ENV
+
+      - name: Build layer qcow2 Image
         working-directory: infrastructure/packer
         run: |
           VERSION_CLEAN="${VERSION#v}"
-          echo "Building version: $VERSION_CLEAN"
+          echo "Building layer for version: $VERSION_CLEAN"
+          echo "Using base image: $BASE_IMAGE"
           packer build \
             -var "version=${VERSION_CLEAN}" \
+            -var "base_image=${BASE_IMAGE}" \
             -on-error=abort \
-            network-agent.pkr.hcl
+            layer.pkr.hcl
 
       - name: Verify build output
         run: |
@@ -241,6 +284,7 @@ jobs:
         run: |
           # Clean up after successful upload to free disk space
           rm -rf infrastructure/packer/output/ || true
+          rm -rf infrastructure/packer/input/ || true
           sudo fstrim -av || true
           echo "Build artifacts uploaded to MinIO and cleaned up"
 

--- a/.github/workflows/base-appliance.yml
+++ b/.github/workflows/base-appliance.yml
@@ -1,0 +1,182 @@
+name: Base Appliance Build
+
+# Monthly base image build (Debian + Docker + Ollama)
+# Uploaded to MinIO appliance-base bucket for layered builds
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_version:
+        description: 'Base version (e.g., 2026-01)'
+        required: true
+        type: string
+      ollama_model:
+        description: 'Primary Ollama model'
+        type: string
+        default: 'qwen3:30b-a3b'
+  schedule:
+    # Run monthly on the 1st at 03:00 UTC
+    - cron: '0 3 1 * *'
+
+concurrency:
+  group: base-appliance-build
+  cancel-in-progress: false
+
+env:
+  PACKER_VERSION: "1.11.0"
+
+permissions:
+  contents: read
+
+jobs:
+  build-base:
+    name: Build Base Image
+    runs-on: self-hosted
+    timeout-minutes: 90
+    outputs:
+      base_version: ${{ steps.version.outputs.BASE_VERSION }}
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            registry-1.docker.io:443
+            auth.docker.io:443
+            production.cloudflare.docker.com:443
+            cdimage.debian.org:443
+            deb.debian.org:443
+            security.debian.org:443
+            registry.ollama.ai:443
+            download.docker.com:443
+            dl.min.io:443
+
+      - uses: actions/checkout@v4
+
+      - name: Set version
+        id: version
+        run: |
+          if [[ -n "${{ inputs.base_version }}" ]]; then
+            BASE_VERSION="${{ inputs.base_version }}"
+          else
+            # Auto-generate from current month
+            BASE_VERSION=$(date +%Y-%m)
+          fi
+          echo "BASE_VERSION=$BASE_VERSION" >> $GITHUB_OUTPUT
+          echo "Building base image: $BASE_VERSION"
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y unzip zstd qemu-utils
+
+      - name: Setup Packer
+        uses: hashicorp/setup-packer@v3
+        with:
+          version: ${{ env.PACKER_VERSION }}
+
+      - name: Verify KVM support
+        run: |
+          if [[ ! -e /dev/kvm ]]; then
+            echo "ERROR: KVM not available. Self-hosted runner requires hardware virtualization."
+            exit 1
+          fi
+          ls -la /dev/kvm
+
+      - name: Initialize Packer
+        working-directory: infrastructure/packer
+        run: packer init .
+
+      - name: Validate base template
+        working-directory: infrastructure/packer
+        run: |
+          packer validate \
+            -var "base_version=${{ steps.version.outputs.BASE_VERSION }}" \
+            base.pkr.hcl
+
+      - name: Build base qcow2 image
+        working-directory: infrastructure/packer
+        env:
+          OLLAMA_MODEL: ${{ inputs.ollama_model || 'qwen3:30b-a3b' }}
+        run: |
+          echo "Building base image version: ${{ steps.version.outputs.BASE_VERSION }}"
+          echo "Ollama model: $OLLAMA_MODEL"
+          packer build \
+            -var "base_version=${{ steps.version.outputs.BASE_VERSION }}" \
+            -var "ollama_model=$OLLAMA_MODEL" \
+            -on-error=abort \
+            base.pkr.hcl
+
+      - name: Verify build output
+        run: |
+          ls -lh infrastructure/packer/output-base/
+          QCOW2_FILE=$(ls infrastructure/packer/output-base/*.qcow2)
+          echo "Built image: $QCOW2_FILE"
+
+      - name: Compress with zstd
+        run: |
+          cd infrastructure/packer/output-base
+          BASE_VERSION="${{ steps.version.outputs.BASE_VERSION }}"
+
+          echo "Compressing with zstd..."
+          zstd -3 -T0 -v *.qcow2 -o "base-${BASE_VERSION}.qcow2.zst"
+
+          echo "Compressed size:"
+          ls -lh *.zst
+
+          echo "Removing original qcow2..."
+          rm -f *.qcow2
+
+      - name: Generate checksum
+        run: |
+          cd infrastructure/packer/output-base
+          sha256sum *.zst > SHA256SUMS
+          cat SHA256SUMS
+
+      - name: Upload to MinIO (appliance-base bucket)
+        env:
+          MINIO_ENDPOINT: ${{ secrets.MINIO_ENDPOINT }}
+          MINIO_ACCESS_KEY: ${{ secrets.MINIO_ACCESS_KEY }}
+          MINIO_SECRET_KEY: ${{ secrets.MINIO_SECRET_KEY }}
+        run: |
+          BASE_VERSION="${{ steps.version.outputs.BASE_VERSION }}"
+
+          # Install mc client
+          wget -q https://dl.min.io/client/mc/release/linux-amd64/mc -O /tmp/mc
+          chmod +x /tmp/mc
+
+          # Configure alias
+          /tmp/mc alias set minio $MINIO_ENDPOINT $MINIO_ACCESS_KEY $MINIO_SECRET_KEY
+
+          # Upload to persistent base bucket
+          /tmp/mc cp infrastructure/packer/output-base/base-${BASE_VERSION}.qcow2.zst minio/appliance-base/
+          /tmp/mc cp infrastructure/packer/output-base/SHA256SUMS minio/appliance-base/SHA256SUMS-${BASE_VERSION}
+
+          # Also upload as "latest" for convenience
+          /tmp/mc cp infrastructure/packer/output-base/base-${BASE_VERSION}.qcow2.zst minio/appliance-base/base-latest.qcow2.zst
+
+          # Verify upload
+          echo "Uploaded to MinIO appliance-base:"
+          /tmp/mc ls minio/appliance-base/
+
+      - name: Cleanup
+        if: always()
+        run: |
+          rm -rf infrastructure/packer/output-base/ || true
+          sudo fstrim -av || true
+          echo "Base image build complete and uploaded to MinIO"
+
+      - name: Summary
+        run: |
+          BASE_VERSION="${{ steps.version.outputs.BASE_VERSION }}"
+          echo "## Base Appliance Build Complete" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Version:** $BASE_VERSION" >> $GITHUB_STEP_SUMMARY
+          echo "- **Location:** MinIO appliance-base bucket" >> $GITHUB_STEP_SUMMARY
+          echo "- **Files:**" >> $GITHUB_STEP_SUMMARY
+          echo "  - \`base-${BASE_VERSION}.qcow2.zst\`" >> $GITHUB_STEP_SUMMARY
+          echo "  - \`base-latest.qcow2.zst\` (symlink)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Use this base image for layered appliance builds." >> $GITHUB_STEP_SUMMARY

--- a/infrastructure/packer/base.pkr.hcl
+++ b/infrastructure/packer/base.pkr.hcl
@@ -1,0 +1,236 @@
+# Network Agent Base Appliance - Packer Template
+# Builds a base qcow2 image with Debian, Docker, and Ollama
+# This is the foundation for layered builds - updated monthly
+#
+# Prerequisites:
+#   - KVM/QEMU with hardware virtualization
+#   - Packer >= 1.11.0
+#   - Internet access for Debian install
+#
+# Build:
+#   packer init .
+#   packer build -var "base_version=2026-01" base.pkr.hcl
+
+packer {
+  required_plugins {
+    qemu = {
+      version = ">= 1.1.0"
+      source  = "github.com/hashicorp/qemu"
+    }
+  }
+}
+
+# Variables
+variable "base_version" {
+  type        = string
+  description = "Base image version (e.g., 2026-01 for January 2026)"
+}
+
+variable "debian_iso_url" {
+  type        = string
+  description = "URL to Debian netinst ISO"
+  default     = "https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/debian-13.3.0-amd64-netinst.iso"
+}
+
+variable "debian_iso_checksum" {
+  type        = string
+  description = "SHA256 checksum of Debian ISO"
+  # Debian 13.3.0 (Trixie) amd64 netinst
+  default     = "sha256:c9f09d24b7e834e6834f2ffa565b33d6f1f540d04bd25c79ad9953bc79a8ac02"
+}
+
+variable "disk_size" {
+  type        = string
+  description = "VM disk size"
+  default     = "100G"
+}
+
+variable "memory" {
+  type        = number
+  description = "VM memory in MB (for build only)"
+  default     = 16384
+}
+
+variable "cpus" {
+  type        = number
+  description = "Number of CPUs (for build only)"
+  default     = 4
+}
+
+variable "ollama_model" {
+  type        = string
+  description = "Ollama model to embed"
+  default     = "qwen3:30b-a3b"
+}
+
+# Local variables
+locals {
+  output_name = "base-${var.base_version}"
+}
+
+# QEMU Builder - produces qcow2 directly
+source "qemu" "base" {
+  iso_url          = var.debian_iso_url
+  iso_checksum     = var.debian_iso_checksum
+  output_directory = "output-base"
+
+  vm_name          = "${local.output_name}.qcow2"
+  format           = "qcow2"
+  disk_size        = var.disk_size
+  disk_compression = true
+
+  memory = var.memory
+  cpus   = var.cpus
+
+  # Modern QEMU settings
+  machine_type   = "q35"
+  accelerator    = "kvm"
+  net_device     = "virtio-net"
+  disk_interface = "virtio-scsi"
+
+  # Debian preseed for unattended install
+  http_directory = "http"
+  boot_wait      = "5s"
+  boot_command = [
+    "<esc><wait>",
+    "auto url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg ",
+    "hostname=network-agent ",
+    "domain=local ",
+    "debian-installer/language=en ",
+    "debian-installer/country=US ",
+    "debian-installer/locale=en_US.UTF-8 ",
+    "keyboard-configuration/xkb-keymap=us ",
+    "<enter>"
+  ]
+
+  # SSH for provisioning
+  ssh_username     = "root"
+  ssh_password     = "packer-build-temp"
+  ssh_timeout      = "30m"
+  ssh_port         = 22
+
+  # Shutdown handled by cleanup provisioner
+  shutdown_command = ""
+
+  # Headless build
+  headless = true
+  display  = "none"
+
+  # VNC for debugging (set headless=false to use)
+  vnc_bind_address = "127.0.0.1"
+  vnc_port_min     = 5900
+  vnc_port_max     = 5999
+
+  # CPU passthrough for better build performance
+  qemuargs = [
+    ["-cpu", "host"]
+  ]
+}
+
+# Build configuration
+build {
+  name    = "base"
+  sources = ["source.qemu.base"]
+
+  # Step 1: Base packages
+  provisioner "shell" {
+    inline = [
+      "apt-get update",
+      "apt-get install -y --no-install-recommends curl ca-certificates gnupg lsb-release sudo vim-tiny htop jq zstd qemu-guest-agent",
+      "systemctl enable qemu-guest-agent"
+    ]
+    environment_vars = ["DEBIAN_FRONTEND=noninteractive"]
+  }
+
+  # Step 2: Docker CE from docker.com
+  provisioner "shell" {
+    inline = [
+      "install -m 0755 -d /etc/apt/keyrings",
+      "curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg",
+      "echo \"deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian trixie stable\" > /etc/apt/sources.list.d/docker.list",
+      "apt-get update",
+      "apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin",
+      "systemctl enable docker"
+    ]
+    environment_vars = ["DEBIAN_FRONTEND=noninteractive"]
+  }
+
+  # Step 3: Hostname & Network (systemd-networkd replaces ifupdown)
+  provisioner "shell" {
+    inline = [
+      "echo 'network-agent' > /etc/hostname",
+      "cat > /etc/hosts << 'EOF'\n127.0.0.1   localhost\n127.0.1.1   network-agent\nEOF",
+      "# Disable ifupdown (conflicts with systemd-networkd)",
+      "mv /etc/network/interfaces /etc/network/interfaces.save 2>/dev/null || true",
+      "mv /etc/network/interfaces.d /etc/network/interfaces.d.save 2>/dev/null || true",
+      "systemctl disable networking.service 2>/dev/null || true",
+      "# Configure systemd-networkd for DHCP on all ethernet interfaces",
+      "mkdir -p /etc/systemd/network",
+      "cat > /etc/systemd/network/20-wired.network << 'EOF'\n[Match]\nType=ether\n\n[Network]\nDHCP=yes\n\n[DHCPv4]\nClientIdentifier=mac\nEOF",
+      "systemctl enable systemd-networkd"
+    ]
+  }
+
+  # Step 4: SSH Hardening
+  provisioner "shell" {
+    inline = [
+      "cat > /etc/ssh/sshd_config.d/99-hardening.conf << 'EOF'\nPermitRootLogin prohibit-password\nPasswordAuthentication no\nPubkeyAuthentication yes\nAuthenticationMethods publickey\nX11Forwarding no\nAllowTcpForwarding no\nMaxAuthTries 3\nEOF"
+    ]
+  }
+
+  # Step 5: Kernel Tuning
+  provisioner "shell" {
+    inline = [
+      "cat > /etc/sysctl.d/99-network-agent.conf << 'EOF'\nnet.ipv4.ping_group_range = 0 65535\nfs.file-max = 1000000\nnet.core.somaxconn = 65535\nnet.ipv4.tcp_tw_reuse = 1\nnet.ipv4.tcp_fin_timeout = 15\nnet.core.rmem_max = 16777216\nnet.core.wmem_max = 16777216\nnet.ipv4.neigh.default.gc_thresh3 = 16384\nEOF",
+      "sysctl --system"
+    ]
+  }
+
+  # Step 6: User Limits
+  provisioner "shell" {
+    inline = [
+      "cat > /etc/security/limits.d/99-network-agent.conf << 'EOF'\n* soft nofile 1000000\n* hard nofile 1000000\nEOF"
+    ]
+  }
+
+  # Step 7: Ollama + Models (takes ~20 min)
+  provisioner "shell" {
+    scripts = [
+      "scripts/03-pull-ollama-model.sh"
+    ]
+    environment_vars = [
+      "DEBIAN_FRONTEND=noninteractive",
+      "OLLAMA_MODEL=${var.ollama_model}"
+    ]
+    execute_command = "chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }}"
+  }
+
+  # Step 8: Write base version marker
+  provisioner "shell" {
+    inline = [
+      "echo '${var.base_version}' > /etc/network-agent-base-version"
+    ]
+  }
+
+  # Step 9: APT Cleanup + Shutdown (skip machine-id/ssh keys - done in layer)
+  provisioner "shell" {
+    skip_clean        = true
+    expect_disconnect = true
+    inline = [
+      "# APT Offline",
+      "cp /etc/apt/sources.list /etc/apt/sources.list.backup 2>/dev/null || true",
+      "echo '# Disabled for offline mode' > /etc/apt/sources.list",
+      "mv /etc/apt/sources.list.d/docker.list /etc/apt/sources.list.d/docker.list.disabled",
+      "apt-get clean && rm -rf /var/lib/apt/lists/*",
+      "# Basic cleanup (NOT machine-id/ssh keys - those are per-release)",
+      "journalctl --vacuum-time=1s",
+      "rm -rf /tmp/* /var/tmp/*",
+      "# Zero free space for better compression",
+      "dd if=/dev/zero of=/EMPTY bs=1M count=5120 2>/dev/null || true",
+      "rm -f /EMPTY",
+      "sync",
+      "# Shutdown",
+      "shutdown -P now"
+    ]
+  }
+}

--- a/infrastructure/packer/layer.pkr.hcl
+++ b/infrastructure/packer/layer.pkr.hcl
@@ -1,0 +1,184 @@
+# Network Agent Layer - Packer Template
+# Builds on top of base image, adding network-agent specific content
+# Fast build (~10 min) for per-release updates
+#
+# Prerequisites:
+#   - Base image from MinIO (appliance-base bucket)
+#   - KVM/QEMU with hardware virtualization
+#   - Packer >= 1.11.0
+#
+# Build:
+#   # Download base image first
+#   mc cp minio/appliance-base/base-2026-01.qcow2 input/
+#   packer build -var "version=0.10.1" -var "base_image=input/base-2026-01.qcow2" layer.pkr.hcl
+
+packer {
+  required_plugins {
+    qemu = {
+      version = ">= 1.1.0"
+      source  = "github.com/hashicorp/qemu"
+    }
+  }
+}
+
+# Variables
+variable "version" {
+  type        = string
+  description = "Appliance version (e.g., 0.10.1)"
+}
+
+variable "base_image" {
+  type        = string
+  description = "Path to base qcow2 image"
+  default     = "input/base.qcow2"
+}
+
+variable "disk_size" {
+  type        = string
+  description = "VM disk size (must match base image)"
+  default     = "100G"
+}
+
+variable "memory" {
+  type        = number
+  description = "VM memory in MB (for build only)"
+  default     = 16384
+}
+
+variable "cpus" {
+  type        = number
+  description = "Number of CPUs (for build only)"
+  default     = 4
+}
+
+# Local variables
+locals {
+  output_name = "network-agent-${var.version}"
+}
+
+# QEMU Builder - starts from base image (not ISO)
+source "qemu" "layer" {
+  # Use existing disk image as base (NOT ISO install)
+  disk_image   = true
+  iso_url      = var.base_image
+  iso_checksum = "none"
+
+  output_directory = "output"
+  vm_name          = "${local.output_name}.qcow2"
+  format           = "qcow2"
+  disk_size        = var.disk_size
+  disk_compression = true
+
+  memory = var.memory
+  cpus   = var.cpus
+
+  # Modern QEMU settings
+  machine_type   = "q35"
+  accelerator    = "kvm"
+  net_device     = "virtio-net"
+  disk_interface = "virtio-scsi"
+
+  # No boot_command needed - boots from disk
+  boot_wait    = "30s"
+  boot_command = []
+
+  # SSH for provisioning (same creds as base)
+  ssh_username     = "root"
+  ssh_password     = "packer-build-temp"
+  ssh_timeout      = "10m"
+  ssh_port         = 22
+
+  # Shutdown handled by cleanup provisioner
+  shutdown_command = ""
+
+  # Headless build
+  headless = true
+  display  = "none"
+
+  # VNC for debugging
+  vnc_bind_address = "127.0.0.1"
+  vnc_port_min     = 5900
+  vnc_port_max     = 5999
+
+  # CPU passthrough
+  qemuargs = [
+    ["-cpu", "host"]
+  ]
+}
+
+# Build configuration
+build {
+  name    = "layer"
+  sources = ["source.qemu.layer"]
+
+  # Step 1: Create target directory
+  provisioner "shell" {
+    inline = ["mkdir -p /opt/network-agent"]
+  }
+
+  # Step 2: Copy Docker Compose files and configs
+  provisioner "file" {
+    source      = "../docker/"
+    destination = "/opt/network-agent/"
+  }
+
+  # Step 3: Copy first-boot script
+  provisioner "file" {
+    source      = "../scripts/first-boot.sh"
+    destination = "/opt/network-agent/first-boot.sh"
+  }
+
+  # Step 4: Write version file
+  provisioner "shell" {
+    inline = [
+      "echo '${var.version}' > /opt/network-agent/VERSION"
+    ]
+  }
+
+  # Step 5: Pull Docker images from ghcr.io for offline use
+  provisioner "shell" {
+    inline = [
+      "# Start Docker (may not be running in base image)",
+      "systemctl start docker",
+      "sleep 5",
+      "# Pull images",
+      "cd /opt/network-agent && VERSION=${var.version} docker compose pull"
+    ]
+  }
+
+  # Step 6: First-boot setup + Firewall configuration
+  provisioner "shell" {
+    scripts = [
+      "scripts/05-first-boot-setup.sh",
+      "scripts/06-configure-firewall.sh"
+    ]
+    environment_vars = [
+      "DEBIAN_FRONTEND=noninteractive",
+      "VERSION=${var.version}"
+    ]
+    execute_command = "chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }}"
+  }
+
+  # Step 7: Final cleanup + Shutdown (must be last!)
+  # This step prepares the image for deployment
+  provisioner "shell" {
+    skip_clean        = true
+    expect_disconnect = true
+    inline = [
+      "# Stop Docker cleanly",
+      "systemctl stop docker",
+      "# Final cleanup",
+      "journalctl --vacuum-time=1s",
+      "rm -rf /tmp/* /var/tmp/*",
+      "# Reset machine identity (unique per deployment)",
+      "rm -f /etc/ssh/ssh_host_*",
+      "truncate -s 0 /etc/machine-id",
+      "# Zero free space for better compression",
+      "dd if=/dev/zero of=/EMPTY bs=1M count=2048 2>/dev/null || true",
+      "rm -f /EMPTY",
+      "sync",
+      "# Shutdown",
+      "shutdown -P now"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Implement layered appliance build system to reduce release builds from ~50 min to ~15 min
- Add `base.pkr.hcl` for monthly base image builds (Debian + Docker + Ollama)
- Add `layer.pkr.hcl` for fast per-release builds
- Add `base-appliance.yml` workflow for monthly base image builds
- Update `appliance-build.yml` to use layered build system

## Architecture

```
BASE IMAGE (monthly, ~40 min)        LAYER (per release, ~15 min)
┌─────────────────────────────┐     ┌─────────────────────────────┐
│ Debian 13 + Docker          │     │ /opt/network-agent/         │
│ Ollama + Models (~20 GB)    │ ──► │ Docker Images Pull          │
│ SSH/Kernel Hardening        │     │ first-boot.sh, Firewall     │
└─────────────────────────────┘     └─────────────────────────────┘
MinIO: appliance-base/              MinIO → GitHub Release
```

## Test Plan
- [x] Packer templates created
- [x] Workflows created
- [ ] CI passes (lint, test, security, docker)
- [ ] Base image build triggered after merge
- [ ] Layer build tested with base image

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)