### PR TITLE
feat(dashboard): add GitHub webhook integration

### DIFF
--- a/infrastructure/cicd-dashboard/app/api/__init__.py
+++ b/infrastructure/cicd-dashboard/app/api/__init__.py
@@ -1,0 +1,5 @@
+"""API routers for CI/CD Dashboard."""
+
+from app.api.webhooks import router as webhooks_router
+
+__all__ = ["webhooks_router"]

--- a/infrastructure/cicd-dashboard/app/api/webhooks.py
+++ b/infrastructure/cicd-dashboard/app/api/webhooks.py
@@ -1,0 +1,122 @@
+"""GitHub webhook API endpoints."""
+
+import logging
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Request
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.database import get_db
+from app.models import WebhookEvent
+from app.schemas import WebhookEventDetailResponse, WebhookEventListResponse
+from app.services.webhook_handler import WebhookHandler, verify_github_signature
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v1/webhooks", tags=["webhooks"])
+
+# Type alias for database dependency
+DB = Annotated[AsyncSession, Depends(get_db)]
+
+
+@router.post("/github", status_code=200)
+async def receive_github_webhook(
+    request: Request,
+    db: DB,
+    x_github_event: Annotated[str, Header()],
+    x_github_delivery: Annotated[str, Header()],
+    x_hub_signature_256: Annotated[str | None, Header()] = None,
+):
+    """Receive and process GitHub webhook events.
+
+    This endpoint validates the webhook signature, stores the event,
+    and processes it to potentially create a new pipeline.
+
+    Returns 200 OK immediately to acknowledge receipt (GitHub best practice).
+    """
+    # Get raw body for signature verification
+    body = await request.body()
+
+    # Verify signature if secret is configured
+    if settings.github_webhook_secret:
+        if not x_hub_signature_256:
+            logger.warning("Missing signature header from %s", x_github_delivery)
+            raise HTTPException(status_code=401, detail="Missing signature")
+
+        if not verify_github_signature(
+            body, x_hub_signature_256, settings.github_webhook_secret
+        ):
+            logger.warning("Invalid signature for delivery %s", x_github_delivery)
+            raise HTTPException(status_code=401, detail="Invalid signature")
+
+    # Parse payload
+    try:
+        payload = await request.json()
+    except Exception as e:
+        logger.error("Failed to parse webhook payload: %s", e)
+        raise HTTPException(status_code=400, detail="Invalid JSON payload")
+
+    # Extract repository info
+    repo = payload.get("repository", {})
+    repo_full_name = repo.get("full_name", "unknown/unknown")
+    action = payload.get("action")
+
+    logger.info(
+        "Received webhook: event=%s action=%s repo=%s delivery=%s",
+        x_github_event,
+        action,
+        repo_full_name,
+        x_github_delivery,
+    )
+
+    # Initialize handler
+    handler = WebhookHandler(db)
+
+    # Check for duplicate
+    if await handler.is_duplicate(x_github_delivery):
+        logger.info("Ignoring duplicate delivery %s", x_github_delivery)
+        return {"status": "ignored", "reason": "duplicate"}
+
+    # Store event
+    event = await handler.store_event(
+        delivery_id=x_github_delivery,
+        event_type=x_github_event,
+        action=action,
+        repo=repo_full_name,
+        payload=payload,
+    )
+
+    # Process event (may create pipeline)
+    pipeline = await handler.process_event(event)
+
+    return {
+        "status": "processed",
+        "event_id": event.id,
+        "pipeline_id": pipeline.id if pipeline else None,
+    }
+
+
+@router.get("/events", response_model=list[WebhookEventListResponse])
+async def list_webhook_events(db: DB, limit: int = 50, offset: int = 0):
+    """List webhook events for debugging."""
+    result = await db.execute(
+        select(WebhookEvent)
+        .order_by(WebhookEvent.created_at.desc())
+        .limit(limit)
+        .offset(offset)
+    )
+    return result.scalars().all()
+
+
+@router.get("/events/{event_id}", response_model=WebhookEventDetailResponse)
+async def get_webhook_event(event_id: str, db: DB):
+    """Get webhook event details including full payload."""
+    result = await db.execute(select(WebhookEvent).where(WebhookEvent.id == event_id))
+    event = result.scalar_one_or_none()
+
+    if not event:
+        raise HTTPException(status_code=404, detail="Event not found")
+
+    return event

--- a/infrastructure/cicd-dashboard/app/main.py
+++ b/infrastructure/cicd-dashboard/app/main.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app import __version__
+from app.api.webhooks import router as webhooks_router
 from app.config import settings
 from app.database import get_db, init_db
 from app.models import Pipeline
@@ -32,6 +33,9 @@ app = FastAPI(
     version=__version__,
     lifespan=lifespan,
 )
+
+# Include routers
+app.include_router(webhooks_router)
 
 
 # Type alias for database dependency

--- a/infrastructure/cicd-dashboard/app/models/__init__.py
+++ b/infrastructure/cicd-dashboard/app/models/__init__.py
@@ -8,11 +8,13 @@ from app.models.pipeline import (
     StepStatus,
 )
 from app.models.approval import Approval
+from app.models.webhook import WebhookEvent
 
 __all__ = [
     "Pipeline",
     "PipelineStep",
     "Approval",
+    "WebhookEvent",
     "PipelineStatus",
     "StepStatus",
     "ApprovalStatus",

--- a/infrastructure/cicd-dashboard/app/models/webhook.py
+++ b/infrastructure/cicd-dashboard/app/models/webhook.py
@@ -1,0 +1,42 @@
+"""WebhookEvent database model."""
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import JSON, DateTime, ForeignKey, String, Text, Boolean
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.pipeline import Base, utcnow
+
+
+class WebhookEvent(Base):
+    """A GitHub webhook event received by the dashboard."""
+
+    __tablename__ = "webhook_events"
+
+    id: Mapped[str] = mapped_column(
+        String(36), primary_key=True, default=lambda: str(uuid.uuid4())
+    )
+    github_delivery_id: Mapped[str] = mapped_column(
+        String(36), unique=True, nullable=False, index=True
+    )
+    event_type: Mapped[str] = mapped_column(String(50), nullable=False)
+    action: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    repo: Mapped[str] = mapped_column(String(255), nullable=False)
+    payload: Mapped[dict] = mapped_column(JSON, nullable=False)
+    processed: Mapped[bool] = mapped_column(Boolean, default=False)
+    processed_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    pipeline_id: Mapped[str | None] = mapped_column(
+        String(36), ForeignKey("pipelines.id"), nullable=True
+    )
+    error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, default=utcnow, nullable=False
+    )
+
+    # Relationships
+    pipeline: Mapped["Pipeline | None"] = relationship("Pipeline")
+
+
+# Forward reference for type hints
+from app.models.pipeline import Pipeline  # noqa: E402, F401

--- a/infrastructure/cicd-dashboard/app/schemas/__init__.py
+++ b/infrastructure/cicd-dashboard/app/schemas/__init__.py
@@ -6,10 +6,18 @@ from app.schemas.pipeline import (
     PipelineListResponse,
     PipelineStepResponse,
 )
+from app.schemas.webhook import (
+    WebhookEventResponse,
+    WebhookEventListResponse,
+    WebhookEventDetailResponse,
+)
 
 __all__ = [
     "PipelineCreate",
     "PipelineResponse",
     "PipelineListResponse",
     "PipelineStepResponse",
+    "WebhookEventResponse",
+    "WebhookEventListResponse",
+    "WebhookEventDetailResponse",
 ]

--- a/infrastructure/cicd-dashboard/app/schemas/webhook.py
+++ b/infrastructure/cicd-dashboard/app/schemas/webhook.py
@@ -1,0 +1,43 @@
+"""Pydantic schemas for Webhook API."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+
+class WebhookEventResponse(BaseModel):
+    """Response schema for a webhook event."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    github_delivery_id: str
+    event_type: str
+    action: str | None = None
+    repo: str
+    processed: bool
+    processed_at: datetime | None = None
+    pipeline_id: str | None = None
+    error: str | None = None
+    created_at: datetime
+
+
+class WebhookEventListResponse(BaseModel):
+    """Response schema for webhook event list (without payload)."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    github_delivery_id: str
+    event_type: str
+    action: str | None = None
+    repo: str
+    processed: bool
+    pipeline_id: str | None = None
+    created_at: datetime
+
+
+class WebhookEventDetailResponse(WebhookEventResponse):
+    """Response schema for webhook event with full payload."""
+
+    payload: dict

--- a/infrastructure/cicd-dashboard/app/services/__init__.py
+++ b/infrastructure/cicd-dashboard/app/services/__init__.py
@@ -1,0 +1,5 @@
+"""Services for CI/CD Dashboard."""
+
+from app.services.webhook_handler import WebhookHandler
+
+__all__ = ["WebhookHandler"]

--- a/infrastructure/cicd-dashboard/app/services/webhook_handler.py
+++ b/infrastructure/cicd-dashboard/app/services/webhook_handler.py
@@ -1,0 +1,237 @@
+"""GitHub webhook event handler service."""
+
+import hashlib
+import hmac
+import logging
+from datetime import UTC, datetime
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import Pipeline, PipelineStatus, WebhookEvent
+
+logger = logging.getLogger(__name__)
+
+
+def verify_github_signature(payload: bytes, signature: str, secret: str) -> bool:
+    """Verify GitHub webhook signature (HMAC-SHA256).
+
+    Args:
+        payload: Raw request body
+        signature: X-Hub-Signature-256 header value
+        secret: Webhook secret from configuration
+
+    Returns:
+        True if signature is valid, False otherwise
+    """
+    if not signature or not signature.startswith("sha256="):
+        return False
+
+    expected = (
+        "sha256="
+        + hmac.new(
+            secret.encode(),
+            payload,
+            hashlib.sha256,
+        ).hexdigest()
+    )
+
+    return hmac.compare_digest(expected, signature)
+
+
+class WebhookHandler:
+    """Handles GitHub webhook events and creates pipelines."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def is_duplicate(self, delivery_id: str) -> bool:
+        """Check if event with this delivery ID already exists."""
+        result = await self.db.execute(
+            select(WebhookEvent).where(WebhookEvent.github_delivery_id == delivery_id)
+        )
+        return result.scalar_one_or_none() is not None
+
+    async def store_event(
+        self,
+        delivery_id: str,
+        event_type: str,
+        action: str | None,
+        repo: str,
+        payload: dict,
+    ) -> WebhookEvent:
+        """Store webhook event in database."""
+        event = WebhookEvent(
+            github_delivery_id=delivery_id,
+            event_type=event_type,
+            action=action,
+            repo=repo,
+            payload=payload,
+        )
+        self.db.add(event)
+        await self.db.flush()
+        await self.db.refresh(event)
+        return event
+
+    async def process_event(self, event: WebhookEvent) -> Pipeline | None:
+        """Process webhook event and optionally create a pipeline.
+
+        Args:
+            event: The webhook event to process
+
+        Returns:
+            Created Pipeline if event triggers one, None otherwise
+        """
+        pipeline = None
+
+        try:
+            # Handle different event types
+            if event.event_type == "issues" and event.action == "labeled":
+                pipeline = await self._handle_issue_labeled(event)
+            elif event.event_type == "pull_request" and event.action == "closed":
+                pipeline = await self._handle_pr_closed(event)
+            elif event.event_type == "workflow_run" and event.action == "completed":
+                await self._handle_workflow_completed(event)
+            elif event.event_type == "release" and event.action == "published":
+                pipeline = await self._handle_release_published(event)
+
+            # Mark event as processed
+            event.processed = True
+            event.processed_at = datetime.now(UTC)
+            if pipeline:
+                event.pipeline_id = pipeline.id
+
+        except Exception as e:
+            logger.exception("Error processing webhook event %s", event.id)
+            event.error = str(e)
+
+        return pipeline
+
+    async def _handle_issue_labeled(self, event: WebhookEvent) -> Pipeline | None:
+        """Handle issue labeled event.
+
+        Creates a new pipeline if the label is 'status:ready'.
+        """
+        payload = event.payload
+        label = payload.get("label", {})
+        label_name = label.get("name", "")
+
+        if label_name != "status:ready":
+            logger.debug("Ignoring label %s (not status:ready)", label_name)
+            return None
+
+        issue = payload.get("issue", {})
+        issue_number = issue.get("number")
+        issue_title = issue.get("title", "")
+
+        logger.info(
+            "Creating pipeline for issue #%s: %s",
+            issue_number,
+            issue_title,
+        )
+
+        pipeline = Pipeline(
+            repo=event.repo,
+            ref="main",  # Default branch, could be configured
+            trigger="issue_labeled",
+            trigger_data={
+                "issue_number": issue_number,
+                "issue_title": issue_title,
+                "label": label_name,
+            },
+        )
+        self.db.add(pipeline)
+        await self.db.flush()
+        await self.db.refresh(pipeline)
+
+        return pipeline
+
+    async def _handle_pr_closed(self, event: WebhookEvent) -> Pipeline | None:
+        """Handle pull request closed event.
+
+        Only processes merged PRs.
+        """
+        payload = event.payload
+        pr = payload.get("pull_request", {})
+
+        if not pr.get("merged"):
+            logger.debug("Ignoring unmerged PR close")
+            return None
+
+        pr_number = pr.get("number")
+        pr_title = pr.get("title", "")
+        merge_commit = pr.get("merge_commit_sha", "")[:7]
+
+        logger.info(
+            "PR #%s merged: %s (commit: %s)",
+            pr_number,
+            pr_title,
+            merge_commit,
+        )
+
+        pipeline = Pipeline(
+            repo=event.repo,
+            ref=f"refs/pull/{pr_number}/merge",
+            trigger="pr_merged",
+            trigger_data={
+                "pr_number": pr_number,
+                "pr_title": pr_title,
+                "merge_commit": merge_commit,
+            },
+        )
+        self.db.add(pipeline)
+        await self.db.flush()
+        await self.db.refresh(pipeline)
+
+        return pipeline
+
+    async def _handle_workflow_completed(self, event: WebhookEvent) -> None:
+        """Handle workflow run completed event.
+
+        Updates existing pipeline step status.
+        """
+        payload = event.payload
+        workflow_run = payload.get("workflow_run", {})
+        conclusion = workflow_run.get("conclusion")
+        workflow_name = workflow_run.get("name", "")
+
+        logger.info(
+            "Workflow '%s' completed with conclusion: %s",
+            workflow_name,
+            conclusion,
+        )
+        # Pipeline step update will be implemented in #75
+
+    async def _handle_release_published(self, event: WebhookEvent) -> Pipeline | None:
+        """Handle release published event."""
+        payload = event.payload
+        release = payload.get("release", {})
+        tag_name = release.get("tag_name", "")
+        release_name = release.get("name", "")
+
+        logger.info(
+            "Release published: %s (%s)",
+            release_name,
+            tag_name,
+        )
+
+        # Extract version from tag (remove 'v' prefix if present)
+        version = tag_name.lstrip("v") if tag_name.startswith("v") else tag_name
+
+        pipeline = Pipeline(
+            repo=event.repo,
+            ref=f"refs/tags/{tag_name}",
+            version=version,
+            status=PipelineStatus.COMPLETED,
+            trigger="release_published",
+            trigger_data={
+                "tag_name": tag_name,
+                "release_name": release_name,
+                "release_id": release.get("id"),
+            },
+        )
+        self.db.add(pipeline)
+        await self.db.flush()
+        await self.db.refresh(pipeline)
+
+        return pipeline

--- a/infrastructure/cicd-dashboard/tests/test_webhooks.py
+++ b/infrastructure/cicd-dashboard/tests/test_webhooks.py
@@ -1,0 +1,272 @@
+"""Tests for webhook API endpoints."""
+
+import hashlib
+import hmac
+import json
+from unittest.mock import patch
+
+import pytest
+
+
+def generate_signature(payload: dict, secret: str) -> str:
+    """Generate a valid GitHub webhook signature."""
+    body = json.dumps(payload).encode()
+    signature = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    return f"sha256={signature}"
+
+
+@pytest.mark.asyncio
+async def test_webhook_missing_signature(client):
+    """Test that missing signature is rejected when secret is configured."""
+    with patch("app.api.webhooks.settings") as mock_settings:
+        mock_settings.github_webhook_secret = "test-secret"
+
+        response = await client.post(
+            "/api/v1/webhooks/github",
+            json={"action": "test"},
+            headers={
+                "X-GitHub-Event": "ping",
+                "X-GitHub-Delivery": "test-delivery-id",
+            },
+        )
+        assert response.status_code == 401
+        assert response.json()["detail"] == "Missing signature"
+
+
+@pytest.mark.asyncio
+async def test_webhook_invalid_signature(client):
+    """Test that invalid signature is rejected."""
+    with patch("app.api.webhooks.settings") as mock_settings:
+        mock_settings.github_webhook_secret = "test-secret"
+
+        response = await client.post(
+            "/api/v1/webhooks/github",
+            json={"action": "test"},
+            headers={
+                "X-GitHub-Event": "ping",
+                "X-GitHub-Delivery": "test-delivery-id",
+                "X-Hub-Signature-256": "sha256=invalid",
+            },
+        )
+        assert response.status_code == 401
+        assert response.json()["detail"] == "Invalid signature"
+
+
+@pytest.mark.asyncio
+async def test_webhook_no_secret_configured(client):
+    """Test that webhooks are accepted when no secret is configured."""
+    with patch("app.api.webhooks.settings") as mock_settings:
+        mock_settings.github_webhook_secret = ""
+
+        payload = {
+            "action": "ping",
+            "repository": {"full_name": "test/repo"},
+        }
+        response = await client.post(
+            "/api/v1/webhooks/github",
+            json=payload,
+            headers={
+                "X-GitHub-Event": "ping",
+                "X-GitHub-Delivery": "test-delivery-001",
+            },
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "processed"
+        assert "event_id" in data
+
+
+@pytest.mark.asyncio
+async def test_webhook_duplicate_ignored(client):
+    """Test that duplicate deliveries are ignored."""
+    with patch("app.api.webhooks.settings") as mock_settings:
+        mock_settings.github_webhook_secret = ""
+
+        payload = {
+            "action": "test",
+            "repository": {"full_name": "test/repo"},
+        }
+
+        # First request
+        response1 = await client.post(
+            "/api/v1/webhooks/github",
+            json=payload,
+            headers={
+                "X-GitHub-Event": "ping",
+                "X-GitHub-Delivery": "duplicate-test-id",
+            },
+        )
+        assert response1.status_code == 200
+        assert response1.json()["status"] == "processed"
+
+        # Second request with same delivery ID
+        response2 = await client.post(
+            "/api/v1/webhooks/github",
+            json=payload,
+            headers={
+                "X-GitHub-Event": "ping",
+                "X-GitHub-Delivery": "duplicate-test-id",
+            },
+        )
+        assert response2.status_code == 200
+        assert response2.json()["status"] == "ignored"
+        assert response2.json()["reason"] == "duplicate"
+
+
+@pytest.mark.asyncio
+async def test_webhook_issue_labeled_status_ready(client):
+    """Test that issue labeled with status:ready creates a pipeline."""
+    with patch("app.api.webhooks.settings") as mock_settings:
+        mock_settings.github_webhook_secret = ""
+
+        payload = {
+            "action": "labeled",
+            "label": {"name": "status:ready"},
+            "issue": {
+                "number": 42,
+                "title": "Test Issue",
+            },
+            "repository": {"full_name": "obtFusi/network-agent"},
+        }
+
+        response = await client.post(
+            "/api/v1/webhooks/github",
+            json=payload,
+            headers={
+                "X-GitHub-Event": "issues",
+                "X-GitHub-Delivery": "issue-labeled-test",
+            },
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "processed"
+        assert data["pipeline_id"] is not None
+
+        # Verify pipeline was created
+        pipeline_response = await client.get(f"/api/v1/pipelines/{data['pipeline_id']}")
+        assert pipeline_response.status_code == 200
+        pipeline = pipeline_response.json()
+        assert pipeline["repo"] == "obtFusi/network-agent"
+        assert pipeline["trigger"] == "issue_labeled"
+
+
+@pytest.mark.asyncio
+async def test_webhook_issue_labeled_other_label(client):
+    """Test that issue labeled with other labels does not create a pipeline."""
+    with patch("app.api.webhooks.settings") as mock_settings:
+        mock_settings.github_webhook_secret = ""
+
+        payload = {
+            "action": "labeled",
+            "label": {"name": "type:bug"},
+            "issue": {
+                "number": 43,
+                "title": "Bug Issue",
+            },
+            "repository": {"full_name": "test/repo"},
+        }
+
+        response = await client.post(
+            "/api/v1/webhooks/github",
+            json=payload,
+            headers={
+                "X-GitHub-Event": "issues",
+                "X-GitHub-Delivery": "issue-other-label-test",
+            },
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "processed"
+        assert data["pipeline_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_webhook_pr_merged(client):
+    """Test that merged PR creates a pipeline."""
+    with patch("app.api.webhooks.settings") as mock_settings:
+        mock_settings.github_webhook_secret = ""
+
+        payload = {
+            "action": "closed",
+            "pull_request": {
+                "number": 123,
+                "title": "feat: Add new feature",
+                "merged": True,
+                "merge_commit_sha": "abc1234567890",
+            },
+            "repository": {"full_name": "obtFusi/network-agent"},
+        }
+
+        response = await client.post(
+            "/api/v1/webhooks/github",
+            json=payload,
+            headers={
+                "X-GitHub-Event": "pull_request",
+                "X-GitHub-Delivery": "pr-merged-test",
+            },
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "processed"
+        assert data["pipeline_id"] is not None
+
+
+@pytest.mark.asyncio
+async def test_webhook_pr_closed_not_merged(client):
+    """Test that closed but not merged PR does not create a pipeline."""
+    with patch("app.api.webhooks.settings") as mock_settings:
+        mock_settings.github_webhook_secret = ""
+
+        payload = {
+            "action": "closed",
+            "pull_request": {
+                "number": 124,
+                "title": "Rejected PR",
+                "merged": False,
+            },
+            "repository": {"full_name": "test/repo"},
+        }
+
+        response = await client.post(
+            "/api/v1/webhooks/github",
+            json=payload,
+            headers={
+                "X-GitHub-Event": "pull_request",
+                "X-GitHub-Delivery": "pr-closed-not-merged-test",
+            },
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "processed"
+        assert data["pipeline_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_list_webhook_events(client):
+    """Test listing webhook events."""
+    with patch("app.api.webhooks.settings") as mock_settings:
+        mock_settings.github_webhook_secret = ""
+
+        # Create some events
+        for i in range(3):
+            await client.post(
+                "/api/v1/webhooks/github",
+                json={"action": "test", "repository": {"full_name": "test/repo"}},
+                headers={
+                    "X-GitHub-Event": "ping",
+                    "X-GitHub-Delivery": f"list-test-{i}",
+                },
+            )
+
+        # List events
+        response = await client.get("/api/v1/webhooks/events")
+        assert response.status_code == 200
+        events = response.json()
+        assert len(events) >= 3
+
+
+@pytest.mark.asyncio
+async def test_get_webhook_event_not_found(client):
+    """Test getting non-existent webhook event returns 404."""
+    response = await client.get("/api/v1/webhooks/events/non-existent-id")
+    assert response.status_code == 404


### PR DESCRIPTION
## Summary
- Add WebhookEvent model for storing GitHub webhook events
- Implement HMAC-SHA256 signature verification for webhook security  
- Add idempotent handling via GitHub delivery ID deduplication
- Create webhook handler service processing: issue labeled, PR merged, workflow completed, release published
- Add API endpoints: POST /github, GET /events, GET /events/{id}
- Add 10 comprehensive tests (17 total now)
- Update CICD.md documentation with webhook setup guide

## Test plan
- [x] All 17 tests pass locally
- [x] Docker build successful
- [x] Webhook endpoint smoke tested with curl
- [x] Local CI (`act push`) all jobs green

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)