### PR TITLE
feat(sse): add Server-Sent Events for real-time updates

### DIFF
--- a/infrastructure/cicd-dashboard/app/api/__init__.py
+++ b/infrastructure/cicd-dashboard/app/api/__init__.py
@@ -1,7 +1,8 @@
 """API routers for CI/CD Dashboard."""
 
 from app.api.approvals import router as approvals_router
+from app.api.events import router as events_router
 from app.api.pipelines import router as pipelines_router
 from app.api.webhooks import router as webhooks_router
 
-__all__ = ["approvals_router", "pipelines_router", "webhooks_router"]
+__all__ = ["approvals_router", "events_router", "pipelines_router", "webhooks_router"]

--- a/infrastructure/cicd-dashboard/app/api/approvals.py
+++ b/infrastructure/cicd-dashboard/app/api/approvals.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import selectinload
 from app.database import get_db
 from app.models import Approval
 from app.services.approval_service import ApprovalError, ApprovalService
+from app.services.event_bus import event_bus
 
 logger = logging.getLogger(__name__)
 
@@ -72,7 +73,7 @@ async def list_pending_approvals(db: DB):
     Returns:
         List of pending approvals with context
     """
-    service = ApprovalService(db)
+    service = ApprovalService(db, event_bus=event_bus)
     approvals = await service.get_pending_approvals()
 
     result = []
@@ -119,7 +120,7 @@ async def get_approval(approval_id: str, db: DB):
     Returns:
         Approval details including status and response
     """
-    service = ApprovalService(db)
+    service = ApprovalService(db, event_bus=event_bus)
     approval = await service.get_approval(approval_id)
 
     if not approval:
@@ -153,7 +154,7 @@ async def approve_request(approval_id: str, request: ApproveRequest, db: DB):
     Returns:
         Updated approval with APPROVED status
     """
-    service = ApprovalService(db)
+    service = ApprovalService(db, event_bus=event_bus)
 
     try:
         await service.approve(approval_id, request.user, request.comment)
@@ -198,7 +199,7 @@ async def reject_request(approval_id: str, request: RejectRequest, db: DB):
     Returns:
         Updated approval with REJECTED status
     """
-    service = ApprovalService(db)
+    service = ApprovalService(db, event_bus=event_bus)
 
     try:
         await service.reject(approval_id, request.user, request.reason)

--- a/infrastructure/cicd-dashboard/app/api/events.py
+++ b/infrastructure/cicd-dashboard/app/api/events.py
@@ -1,0 +1,152 @@
+"""Server-Sent Events (SSE) streaming API endpoints."""
+
+import asyncio
+import logging
+from collections.abc import AsyncIterator
+
+from fastapi import APIRouter, Query, Request
+from fastapi.responses import StreamingResponse
+
+from app.services.event_bus import event_bus
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v1/events", tags=["events"])
+
+
+async def event_generator(
+    request: Request,
+    pipeline_id: str | None = None,
+    replay: bool = False,
+) -> AsyncIterator[str]:
+    """Generate SSE events for streaming.
+
+    Args:
+        request: The FastAPI request (for disconnect detection)
+        pipeline_id: Optional filter for specific pipeline
+        replay: Whether to replay buffered events
+
+    Yields:
+        Formatted SSE event strings
+    """
+    try:
+        async for event in event_bus.subscribe(pipeline_id=pipeline_id, replay=replay):
+            # Check if client disconnected
+            if await request.is_disconnected():
+                logger.info("Client disconnected, stopping event stream")
+                break
+
+            yield event.format()
+
+    except asyncio.CancelledError:
+        logger.info("Event stream cancelled")
+        raise
+
+
+@router.get("/stream")
+async def stream_events(
+    request: Request,
+    pipeline_id: str | None = Query(
+        None, description="Filter events for a specific pipeline"
+    ),
+    replay: bool = Query(False, description="Replay buffered events on connect"),
+) -> StreamingResponse:
+    """Stream real-time events via Server-Sent Events (SSE).
+
+    This endpoint establishes a long-running connection that streams events
+    as they occur. Events are formatted according to the SSE specification.
+
+    **Event Types:**
+    - `pipeline.created` - New pipeline created
+    - `pipeline.updated` - Pipeline status changed
+    - `pipeline.completed` - Pipeline finished (success/failure)
+    - `step.started` - Pipeline step started
+    - `step.completed` - Pipeline step finished
+    - `step.log` - Log line from a step
+    - `approval.requested` - Approval gate waiting
+    - `approval.resolved` - Approval granted/rejected
+    - `heartbeat` - Keep-alive signal (every 30s)
+
+    **Usage:**
+    ```javascript
+    const eventSource = new EventSource('/api/v1/events/stream');
+    eventSource.addEventListener('pipeline.updated', (e) => {
+        const data = JSON.parse(e.data);
+        console.log('Pipeline updated:', data);
+    });
+    ```
+
+    Args:
+        pipeline_id: Optional filter for a specific pipeline's events
+        replay: If true, replay recent buffered events on connect
+
+    Returns:
+        StreamingResponse with SSE content type
+    """
+    logger.info(
+        "SSE stream started (pipeline_id=%s, replay=%s)",
+        pipeline_id,
+        replay,
+    )
+
+    return StreamingResponse(
+        event_generator(request, pipeline_id=pipeline_id, replay=replay),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",  # Disable nginx buffering
+        },
+    )
+
+
+@router.get("/stream/{pipeline_id}")
+async def stream_pipeline_events(
+    request: Request,
+    pipeline_id: str,
+    replay: bool = Query(False, description="Replay buffered events on connect"),
+) -> StreamingResponse:
+    """Stream events for a specific pipeline.
+
+    This is a convenience endpoint equivalent to `/stream?pipeline_id=<id>`.
+    Only events related to the specified pipeline will be streamed.
+
+    Args:
+        pipeline_id: The pipeline ID to filter events for
+        replay: If true, replay recent buffered events on connect
+
+    Returns:
+        StreamingResponse with SSE content type
+    """
+    logger.info(
+        "SSE stream started for pipeline %s (replay=%s)",
+        pipeline_id,
+        replay,
+    )
+
+    return StreamingResponse(
+        event_generator(request, pipeline_id=pipeline_id, replay=replay),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
+@router.get("/stats")
+async def get_event_stats() -> dict:
+    """Get event stream statistics.
+
+    Returns current subscriber count and buffer status.
+    Useful for monitoring and debugging.
+
+    Returns:
+        Dict with subscriber_count and buffer_size
+    """
+    return {
+        "subscriber_count": event_bus.subscriber_count,
+        "buffer_size": len(event_bus._buffer),
+        "buffer_capacity": event_bus._buffer_size,
+    }

--- a/infrastructure/cicd-dashboard/app/api/pipelines.py
+++ b/infrastructure/cicd-dashboard/app/api/pipelines.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import selectinload
 from app.database import get_db
 from app.models import Pipeline, PipelineStatus
 from app.schemas import PipelineResponse
+from app.services.event_bus import event_bus
 from app.services.pipeline_executor import PipelineExecutor, PipelineExecutorError
 
 logger = logging.getLogger(__name__)
@@ -29,7 +30,7 @@ def get_executor(db: AsyncSession) -> PipelineExecutor:
     """Get or create the pipeline executor."""
     global _executor
     if _executor is None:
-        _executor = PipelineExecutor(db)
+        _executor = PipelineExecutor(db, event_bus=event_bus)
     else:
         _executor.db = db
     return _executor

--- a/infrastructure/cicd-dashboard/app/schemas/__init__.py
+++ b/infrastructure/cicd-dashboard/app/schemas/__init__.py
@@ -1,5 +1,19 @@
 """Pydantic schemas for API request/response models."""
 
+from app.schemas.event import (
+    EventType,
+    SSEEvent,
+    PipelineCreatedPayload,
+    PipelineUpdatedPayload,
+    PipelineCompletedPayload,
+    StepStartedPayload,
+    StepCompletedPayload,
+    StepLogPayload,
+    ApprovalRequestedPayload,
+    ApprovalResolvedPayload,
+    HeartbeatPayload,
+    ErrorPayload,
+)
 from app.schemas.pipeline import (
     PipelineCreate,
     PipelineResponse,
@@ -13,10 +27,25 @@ from app.schemas.webhook import (
 )
 
 __all__ = [
+    # Event schemas
+    "EventType",
+    "SSEEvent",
+    "PipelineCreatedPayload",
+    "PipelineUpdatedPayload",
+    "PipelineCompletedPayload",
+    "StepStartedPayload",
+    "StepCompletedPayload",
+    "StepLogPayload",
+    "ApprovalRequestedPayload",
+    "ApprovalResolvedPayload",
+    "HeartbeatPayload",
+    "ErrorPayload",
+    # Pipeline schemas
     "PipelineCreate",
     "PipelineResponse",
     "PipelineListResponse",
     "PipelineStepResponse",
+    # Webhook schemas
     "WebhookEventResponse",
     "WebhookEventListResponse",
     "WebhookEventDetailResponse",

--- a/infrastructure/cicd-dashboard/app/schemas/event.py
+++ b/infrastructure/cicd-dashboard/app/schemas/event.py
@@ -1,0 +1,145 @@
+"""Pydantic schemas for Server-Sent Events (SSE)."""
+
+from datetime import datetime
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+
+class EventType(str, Enum):
+    """Event types for SSE streaming."""
+
+    # Pipeline events
+    PIPELINE_CREATED = "pipeline.created"
+    PIPELINE_UPDATED = "pipeline.updated"
+    PIPELINE_COMPLETED = "pipeline.completed"
+
+    # Step events
+    STEP_STARTED = "step.started"
+    STEP_COMPLETED = "step.completed"
+    STEP_LOG = "step.log"
+
+    # Approval events
+    APPROVAL_REQUESTED = "approval.requested"
+    APPROVAL_RESOLVED = "approval.resolved"
+
+    # System events
+    HEARTBEAT = "heartbeat"
+    ERROR = "error"
+
+
+class PipelineCreatedPayload(BaseModel):
+    """Payload for pipeline.created event."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    repo: str
+    version: str | None
+    status: str
+    trigger: str
+    created_at: datetime
+
+
+class PipelineUpdatedPayload(BaseModel):
+    """Payload for pipeline.updated event."""
+
+    id: str
+    status: str
+    current_step: str | None = None
+
+
+class PipelineCompletedPayload(BaseModel):
+    """Payload for pipeline.completed event."""
+
+    id: str
+    status: str
+    duration_seconds: float | None = None
+
+
+class StepStartedPayload(BaseModel):
+    """Payload for step.started event."""
+
+    pipeline_id: str
+    step_id: str
+    name: str
+    stage: str
+
+
+class StepCompletedPayload(BaseModel):
+    """Payload for step.completed event."""
+
+    pipeline_id: str
+    step_id: str
+    name: str
+    status: str
+    duration_seconds: float | None = None
+    error: str | None = None
+
+
+class StepLogPayload(BaseModel):
+    """Payload for step.log event."""
+
+    pipeline_id: str
+    step_id: str
+    line: str
+    timestamp: datetime
+
+
+class ApprovalRequestedPayload(BaseModel):
+    """Payload for approval.requested event."""
+
+    id: str
+    pipeline_id: str
+    step_id: str
+    step_name: str
+    requested_at: datetime
+
+
+class ApprovalResolvedPayload(BaseModel):
+    """Payload for approval.resolved event."""
+
+    id: str
+    pipeline_id: str
+    status: str
+    responded_by: str | None
+    responded_at: datetime | None
+
+
+class HeartbeatPayload(BaseModel):
+    """Payload for heartbeat event."""
+
+    timestamp: datetime
+    server_id: str = "cicd-dashboard"
+
+
+class ErrorPayload(BaseModel):
+    """Payload for error event."""
+
+    message: str
+    code: str | None = None
+
+
+class SSEEvent(BaseModel):
+    """Server-Sent Event wrapper."""
+
+    type: EventType
+    data: dict[str, Any]
+    id: str | None = None
+    retry: int | None = None
+
+    def format(self) -> str:
+        """Format event as SSE string."""
+        lines = []
+        if self.id:
+            lines.append(f"id: {self.id}")
+        lines.append(f"event: {self.type.value}")
+        # Convert data to JSON string
+        import json
+
+        lines.append(f"data: {json.dumps(self.data, default=str)}")
+        if self.retry:
+            lines.append(f"retry: {self.retry}")
+        lines.append("")  # Empty line to end the event
+        return "\n".join(lines) + "\n"

--- a/infrastructure/cicd-dashboard/app/services/__init__.py
+++ b/infrastructure/cicd-dashboard/app/services/__init__.py
@@ -1,13 +1,17 @@
 """Services for CI/CD Dashboard."""
 
 from app.services.approval_service import ApprovalService
+from app.services.event_bus import EventBus, event_bus, heartbeat_task
 from app.services.github_client import GitHubClient
 from app.services.pipeline_executor import PipelineExecutor
 from app.services.webhook_handler import WebhookHandler
 
 __all__ = [
     "ApprovalService",
+    "EventBus",
     "GitHubClient",
     "PipelineExecutor",
     "WebhookHandler",
+    "event_bus",
+    "heartbeat_task",
 ]

--- a/infrastructure/cicd-dashboard/app/services/event_bus.py
+++ b/infrastructure/cicd-dashboard/app/services/event_bus.py
@@ -1,0 +1,319 @@
+"""Event bus for Server-Sent Events (SSE) pub/sub."""
+
+import asyncio
+import logging
+import uuid
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+from app.schemas.event import (
+    ApprovalRequestedPayload,
+    ApprovalResolvedPayload,
+    EventType,
+    HeartbeatPayload,
+    PipelineCompletedPayload,
+    PipelineCreatedPayload,
+    PipelineUpdatedPayload,
+    SSEEvent,
+    StepCompletedPayload,
+    StepLogPayload,
+    StepStartedPayload,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class EventBus:
+    """In-memory event bus with async pub/sub for SSE.
+
+    Features:
+    - Multiple subscribers can receive events
+    - Per-pipeline filtering for log streams
+    - Heartbeat mechanism to keep connections alive
+    - Event buffering for late-joining subscribers
+    """
+
+    def __init__(self, buffer_size: int = 100):
+        """Initialize the event bus.
+
+        Args:
+            buffer_size: Number of events to buffer for replay
+        """
+        self._subscribers: dict[str, asyncio.Queue[SSEEvent]] = {}
+        self._buffer: list[SSEEvent] = []
+        self._buffer_size = buffer_size
+        self._lock = asyncio.Lock()
+        self._event_counter = 0
+
+    async def subscribe(
+        self,
+        pipeline_id: str | None = None,
+        replay: bool = False,
+    ) -> AsyncIterator[SSEEvent]:
+        """Subscribe to events.
+
+        Args:
+            pipeline_id: Optional filter for specific pipeline events
+            replay: Whether to replay buffered events
+
+        Yields:
+            SSEEvent objects as they arrive
+        """
+        subscriber_id = str(uuid.uuid4())
+        queue: asyncio.Queue[SSEEvent] = asyncio.Queue()
+
+        async with self._lock:
+            self._subscribers[subscriber_id] = queue
+            logger.info(
+                "Subscriber %s connected (pipeline_filter=%s, replay=%s)",
+                subscriber_id,
+                pipeline_id,
+                replay,
+            )
+
+            # Replay buffered events if requested
+            if replay:
+                for event in self._buffer:
+                    if self._matches_filter(event, pipeline_id):
+                        await queue.put(event)
+
+        try:
+            while True:
+                event = await queue.get()
+                if self._matches_filter(event, pipeline_id):
+                    yield event
+        finally:
+            async with self._lock:
+                self._subscribers.pop(subscriber_id, None)
+                logger.info("Subscriber %s disconnected", subscriber_id)
+
+    def _matches_filter(self, event: SSEEvent, pipeline_id: str | None) -> bool:
+        """Check if event matches the pipeline filter.
+
+        Args:
+            event: The event to check
+            pipeline_id: Optional pipeline ID to filter by
+
+        Returns:
+            True if event matches filter or no filter is set
+        """
+        if pipeline_id is None:
+            return True
+
+        # System events always pass through
+        if event.type in (EventType.HEARTBEAT, EventType.ERROR):
+            return True
+
+        # Check for pipeline_id in event data
+        return (
+            event.data.get("pipeline_id") == pipeline_id
+            or event.data.get("id") == pipeline_id
+        )
+
+    async def publish(self, event: SSEEvent) -> None:
+        """Publish an event to all subscribers.
+
+        Args:
+            event: The event to publish
+        """
+        async with self._lock:
+            # Assign event ID
+            self._event_counter += 1
+            event.id = str(self._event_counter)
+
+            # Add to buffer
+            self._buffer.append(event)
+            if len(self._buffer) > self._buffer_size:
+                self._buffer.pop(0)
+
+            # Distribute to all subscribers
+            for subscriber_id, queue in self._subscribers.items():
+                try:
+                    queue.put_nowait(event)
+                except asyncio.QueueFull:
+                    logger.warning(
+                        "Queue full for subscriber %s, dropping event", subscriber_id
+                    )
+
+        logger.debug("Published event %s (id=%s)", event.type.value, event.id)
+
+    async def publish_pipeline_created(
+        self,
+        pipeline_id: str,
+        repo: str,
+        version: str | None,
+        status: str,
+        trigger: str,
+        created_at: datetime,
+    ) -> None:
+        """Publish a pipeline.created event."""
+        payload = PipelineCreatedPayload(
+            id=pipeline_id,
+            repo=repo,
+            version=version,
+            status=status,
+            trigger=trigger,
+            created_at=created_at,
+        )
+        await self.publish(
+            SSEEvent(type=EventType.PIPELINE_CREATED, data=payload.model_dump())
+        )
+
+    async def publish_pipeline_updated(
+        self,
+        pipeline_id: str,
+        status: str,
+        current_step: str | None = None,
+    ) -> None:
+        """Publish a pipeline.updated event."""
+        payload = PipelineUpdatedPayload(
+            id=pipeline_id,
+            status=status,
+            current_step=current_step,
+        )
+        await self.publish(
+            SSEEvent(type=EventType.PIPELINE_UPDATED, data=payload.model_dump())
+        )
+
+    async def publish_pipeline_completed(
+        self,
+        pipeline_id: str,
+        status: str,
+        duration_seconds: float | None = None,
+    ) -> None:
+        """Publish a pipeline.completed event."""
+        payload = PipelineCompletedPayload(
+            id=pipeline_id,
+            status=status,
+            duration_seconds=duration_seconds,
+        )
+        await self.publish(
+            SSEEvent(type=EventType.PIPELINE_COMPLETED, data=payload.model_dump())
+        )
+
+    async def publish_step_started(
+        self,
+        pipeline_id: str,
+        step_id: str,
+        name: str,
+        stage: str,
+    ) -> None:
+        """Publish a step.started event."""
+        payload = StepStartedPayload(
+            pipeline_id=pipeline_id,
+            step_id=step_id,
+            name=name,
+            stage=stage,
+        )
+        await self.publish(
+            SSEEvent(type=EventType.STEP_STARTED, data=payload.model_dump())
+        )
+
+    async def publish_step_completed(
+        self,
+        pipeline_id: str,
+        step_id: str,
+        name: str,
+        status: str,
+        duration_seconds: float | None = None,
+        error: str | None = None,
+    ) -> None:
+        """Publish a step.completed event."""
+        payload = StepCompletedPayload(
+            pipeline_id=pipeline_id,
+            step_id=step_id,
+            name=name,
+            status=status,
+            duration_seconds=duration_seconds,
+            error=error,
+        )
+        await self.publish(
+            SSEEvent(type=EventType.STEP_COMPLETED, data=payload.model_dump())
+        )
+
+    async def publish_step_log(
+        self,
+        pipeline_id: str,
+        step_id: str,
+        line: str,
+    ) -> None:
+        """Publish a step.log event."""
+        payload = StepLogPayload(
+            pipeline_id=pipeline_id,
+            step_id=step_id,
+            line=line,
+            timestamp=datetime.now(UTC),
+        )
+        await self.publish(SSEEvent(type=EventType.STEP_LOG, data=payload.model_dump()))
+
+    async def publish_approval_requested(
+        self,
+        approval_id: str,
+        pipeline_id: str,
+        step_id: str,
+        step_name: str,
+        requested_at: datetime,
+    ) -> None:
+        """Publish an approval.requested event."""
+        payload = ApprovalRequestedPayload(
+            id=approval_id,
+            pipeline_id=pipeline_id,
+            step_id=step_id,
+            step_name=step_name,
+            requested_at=requested_at,
+        )
+        await self.publish(
+            SSEEvent(type=EventType.APPROVAL_REQUESTED, data=payload.model_dump())
+        )
+
+    async def publish_approval_resolved(
+        self,
+        approval_id: str,
+        pipeline_id: str,
+        status: str,
+        responded_by: str | None,
+        responded_at: datetime | None,
+    ) -> None:
+        """Publish an approval.resolved event."""
+        payload = ApprovalResolvedPayload(
+            id=approval_id,
+            pipeline_id=pipeline_id,
+            status=status,
+            responded_by=responded_by,
+            responded_at=responded_at,
+        )
+        await self.publish(
+            SSEEvent(type=EventType.APPROVAL_RESOLVED, data=payload.model_dump())
+        )
+
+    async def publish_heartbeat(self) -> None:
+        """Publish a heartbeat event."""
+        payload = HeartbeatPayload(timestamp=datetime.now(UTC))
+        await self.publish(
+            SSEEvent(type=EventType.HEARTBEAT, data=payload.model_dump())
+        )
+
+    @property
+    def subscriber_count(self) -> int:
+        """Return the number of active subscribers."""
+        return len(self._subscribers)
+
+    def clear_buffer(self) -> None:
+        """Clear the event buffer."""
+        self._buffer.clear()
+
+
+# Global event bus instance
+event_bus = EventBus()
+
+
+async def heartbeat_task(interval: float = 30.0) -> None:
+    """Background task to send periodic heartbeats.
+
+    Args:
+        interval: Seconds between heartbeats (default 30s)
+    """
+    while True:
+        await asyncio.sleep(interval)
+        if event_bus.subscriber_count > 0:
+            await event_bus.publish_heartbeat()
+            logger.debug("Heartbeat sent to %d subscribers", event_bus.subscriber_count)

--- a/infrastructure/cicd-dashboard/docs/sse-events.md
+++ b/infrastructure/cicd-dashboard/docs/sse-events.md
@@ -1,0 +1,149 @@
+# Server-Sent Events (SSE) API
+
+Real-time event streaming for the CI/CD Dashboard.
+
+## Overview
+
+The SSE endpoint allows clients to receive real-time updates about pipeline execution, step progress, and approval requests without polling.
+
+## Endpoints
+
+### `GET /api/v1/events/stream`
+
+Main SSE streaming endpoint.
+
+**Query Parameters:**
+- `pipeline_id` (optional): Filter events for a specific pipeline
+- `replay` (optional): If true, replay buffered events on connect
+
+**Headers:**
+```
+Accept: text/event-stream
+Cache-Control: no-cache
+Connection: keep-alive
+```
+
+### `GET /api/v1/events/stream/{pipeline_id}`
+
+Convenience endpoint for pipeline-specific events.
+
+### `GET /api/v1/events/stats`
+
+Get current event stream statistics.
+
+**Response:**
+```json
+{
+  "subscriber_count": 3,
+  "buffer_size": 42,
+  "buffer_capacity": 100
+}
+```
+
+## Event Types
+
+| Event | Payload | Description |
+|-------|---------|-------------|
+| `pipeline.created` | `{id, repo, version, status, trigger, created_at}` | New pipeline created |
+| `pipeline.updated` | `{id, status, current_step}` | Pipeline status changed |
+| `pipeline.completed` | `{id, status, duration_seconds}` | Pipeline finished |
+| `step.started` | `{pipeline_id, step_id, name, stage}` | Step execution started |
+| `step.completed` | `{pipeline_id, step_id, name, status, duration_seconds, error}` | Step finished |
+| `step.log` | `{pipeline_id, step_id, line, timestamp}` | Log line from step |
+| `approval.requested` | `{id, pipeline_id, step_id, step_name, requested_at}` | Approval needed |
+| `approval.resolved` | `{id, pipeline_id, status, responded_by, responded_at}` | Approval granted/rejected |
+| `heartbeat` | `{timestamp, server_id}` | Keep-alive signal (every 30s) |
+
+## Usage Examples
+
+### JavaScript (Browser)
+
+```javascript
+const eventSource = new EventSource('/api/v1/events/stream');
+
+// Listen to all events
+eventSource.onmessage = (event) => {
+  const data = JSON.parse(event.data);
+  console.log('Event:', event.type, data);
+};
+
+// Listen to specific event types
+eventSource.addEventListener('pipeline.updated', (event) => {
+  const data = JSON.parse(event.data);
+  updatePipelineUI(data.id, data.status);
+});
+
+eventSource.addEventListener('approval.requested', (event) => {
+  const data = JSON.parse(event.data);
+  showApprovalNotification(data);
+});
+
+// Handle errors
+eventSource.onerror = (error) => {
+  console.error('SSE error:', error);
+  // Browser automatically reconnects
+};
+```
+
+### Filter by Pipeline
+
+```javascript
+const pipelineId = 'abc-123';
+const eventSource = new EventSource(
+  `/api/v1/events/stream?pipeline_id=${pipelineId}`
+);
+```
+
+### Replay Buffered Events
+
+```javascript
+// Get events that occurred before connecting
+const eventSource = new EventSource('/api/v1/events/stream?replay=true');
+```
+
+### Python Client
+
+```python
+import httpx
+
+async def stream_events():
+    async with httpx.AsyncClient() as client:
+        async with client.stream('GET', 'http://localhost:8000/api/v1/events/stream') as response:
+            async for line in response.aiter_lines():
+                if line.startswith('data:'):
+                    data = json.loads(line[5:])
+                    print(f"Event: {data}")
+```
+
+## Event Bus Architecture
+
+The event bus uses an in-memory pub/sub pattern:
+
+```
+┌─────────────────┐     ┌─────────────────┐
+│ PipelineExecutor│────▶│    EventBus     │
+└─────────────────┘     │  (In-Memory)    │
+                        │                 │
+┌─────────────────┐     │  ┌───────────┐  │     ┌───────────┐
+│ ApprovalService │────▶│  │  Buffer   │  │────▶│ Subscriber│
+└─────────────────┘     │  │ (100 max) │  │     └───────────┘
+                        │  └───────────┘  │     ┌───────────┐
+                        │                 │────▶│ Subscriber│
+                        └─────────────────┘     └───────────┘
+```
+
+Features:
+- **Multiple subscribers**: All connected clients receive all events
+- **Pipeline filtering**: Clients can filter for specific pipeline events
+- **Event buffering**: Last 100 events are buffered for replay
+- **Heartbeat**: 30-second keep-alive signals
+- **Auto-cleanup**: Disconnected subscribers are removed automatically
+
+## Configuration
+
+The event bus uses sensible defaults:
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| Buffer size | 100 | Number of events to keep for replay |
+| Heartbeat interval | 30s | Keep-alive signal frequency |

--- a/infrastructure/cicd-dashboard/tests/test_event_bus.py
+++ b/infrastructure/cicd-dashboard/tests/test_event_bus.py
@@ -1,0 +1,315 @@
+"""Tests for Event Bus service."""
+
+import asyncio
+from datetime import UTC, datetime
+
+import pytest
+
+from app.schemas.event import EventType, SSEEvent
+from app.services.event_bus import EventBus
+
+
+@pytest.fixture
+def event_bus():
+    """Create a fresh event bus for each test."""
+    return EventBus(buffer_size=10)
+
+
+@pytest.mark.asyncio
+async def test_event_bus_subscribe_and_publish(event_bus):
+    """Test basic subscribe and publish."""
+    received_events = []
+
+    async def collect_events():
+        async for event in event_bus.subscribe():
+            received_events.append(event)
+            if len(received_events) >= 1:
+                break
+
+    # Start subscriber in background
+    subscriber_task = asyncio.create_task(collect_events())
+
+    # Wait for subscriber to be ready
+    await asyncio.sleep(0.1)
+
+    # Publish event
+    await event_bus.publish_heartbeat()
+
+    # Wait for event to be received
+    await asyncio.wait_for(subscriber_task, timeout=1.0)
+
+    assert len(received_events) == 1
+    assert received_events[0].type == EventType.HEARTBEAT
+
+
+@pytest.mark.asyncio
+async def test_event_bus_multiple_subscribers(event_bus):
+    """Test multiple subscribers receive same events."""
+    received1 = []
+    received2 = []
+
+    async def collect_events1():
+        async for event in event_bus.subscribe():
+            received1.append(event)
+            if len(received1) >= 1:
+                break
+
+    async def collect_events2():
+        async for event in event_bus.subscribe():
+            received2.append(event)
+            if len(received2) >= 1:
+                break
+
+    task1 = asyncio.create_task(collect_events1())
+    task2 = asyncio.create_task(collect_events2())
+
+    await asyncio.sleep(0.1)
+
+    await event_bus.publish_heartbeat()
+
+    await asyncio.wait_for(asyncio.gather(task1, task2), timeout=1.0)
+
+    assert len(received1) == 1
+    assert len(received2) == 1
+
+
+@pytest.mark.asyncio
+async def test_event_bus_pipeline_filter(event_bus):
+    """Test filtering events by pipeline ID."""
+    received = []
+    target_pipeline = "pipeline-123"
+
+    async def collect_events():
+        async for event in event_bus.subscribe(pipeline_id=target_pipeline):
+            received.append(event)
+            if len(received) >= 2:
+                break
+
+    task = asyncio.create_task(collect_events())
+    await asyncio.sleep(0.1)
+
+    # Publish events for different pipelines
+    await event_bus.publish_pipeline_updated(
+        pipeline_id=target_pipeline,
+        status="running",
+    )
+    await event_bus.publish_pipeline_updated(
+        pipeline_id="other-pipeline",
+        status="running",
+    )
+    await event_bus.publish_heartbeat()  # Should pass through filter
+
+    await asyncio.wait_for(task, timeout=1.0)
+
+    assert len(received) == 2
+    # First event should be the matching pipeline
+    assert received[0].data.get("id") == target_pipeline
+    # Second event should be heartbeat (always passes)
+    assert received[1].type == EventType.HEARTBEAT
+
+
+@pytest.mark.asyncio
+async def test_event_bus_replay(event_bus):
+    """Test replaying buffered events."""
+    # Publish events before subscribing
+    await event_bus.publish_heartbeat()
+    await event_bus.publish_pipeline_updated(
+        pipeline_id="test-pipeline",
+        status="running",
+    )
+
+    received = []
+
+    async def collect_events():
+        async for event in event_bus.subscribe(replay=True):
+            received.append(event)
+            if len(received) >= 2:
+                break
+
+    task = asyncio.create_task(collect_events())
+    await asyncio.wait_for(task, timeout=1.0)
+
+    assert len(received) == 2
+
+
+@pytest.mark.asyncio
+async def test_event_bus_buffer_limit(event_bus):
+    """Test buffer size limit."""
+    # Buffer size is 10, publish 15 events
+    for i in range(15):
+        await event_bus.publish(
+            SSEEvent(
+                type=EventType.HEARTBEAT,
+                data={"index": i},
+            )
+        )
+
+    # Buffer should only have last 10 events
+    assert len(event_bus._buffer) == 10
+    assert event_bus._buffer[0].data["index"] == 5  # First kept event
+
+
+@pytest.mark.asyncio
+async def test_event_bus_event_ids(event_bus):
+    """Test that events get sequential IDs."""
+    await event_bus.publish_heartbeat()
+    await event_bus.publish_heartbeat()
+    await event_bus.publish_heartbeat()
+
+    assert event_bus._buffer[0].id == "1"
+    assert event_bus._buffer[1].id == "2"
+    assert event_bus._buffer[2].id == "3"
+
+
+@pytest.mark.asyncio
+async def test_publish_pipeline_created(event_bus):
+    """Test publishing pipeline created event."""
+    now = datetime.now(UTC)
+
+    await event_bus.publish_pipeline_created(
+        pipeline_id="test-id",
+        repo="test/repo",
+        version="1.0.0",
+        status="pending",
+        trigger="manual",
+        created_at=now,
+    )
+
+    assert len(event_bus._buffer) == 1
+    event = event_bus._buffer[0]
+    assert event.type == EventType.PIPELINE_CREATED
+    assert event.data["id"] == "test-id"
+    assert event.data["repo"] == "test/repo"
+    assert event.data["version"] == "1.0.0"
+
+
+@pytest.mark.asyncio
+async def test_publish_step_started(event_bus):
+    """Test publishing step started event."""
+    await event_bus.publish_step_started(
+        pipeline_id="pipeline-1",
+        step_id="step-1",
+        name="lint",
+        stage="validate",
+    )
+
+    event = event_bus._buffer[0]
+    assert event.type == EventType.STEP_STARTED
+    assert event.data["pipeline_id"] == "pipeline-1"
+    assert event.data["step_id"] == "step-1"
+    assert event.data["name"] == "lint"
+    assert event.data["stage"] == "validate"
+
+
+@pytest.mark.asyncio
+async def test_publish_step_completed(event_bus):
+    """Test publishing step completed event."""
+    await event_bus.publish_step_completed(
+        pipeline_id="pipeline-1",
+        step_id="step-1",
+        name="lint",
+        status="completed",
+        duration_seconds=45.5,
+    )
+
+    event = event_bus._buffer[0]
+    assert event.type == EventType.STEP_COMPLETED
+    assert event.data["status"] == "completed"
+    assert event.data["duration_seconds"] == 45.5
+
+
+@pytest.mark.asyncio
+async def test_publish_approval_requested(event_bus):
+    """Test publishing approval requested event."""
+    now = datetime.now(UTC)
+
+    await event_bus.publish_approval_requested(
+        approval_id="approval-1",
+        pipeline_id="pipeline-1",
+        step_id="step-1",
+        step_name="pr-merge",
+        requested_at=now,
+    )
+
+    event = event_bus._buffer[0]
+    assert event.type == EventType.APPROVAL_REQUESTED
+    assert event.data["id"] == "approval-1"
+    assert event.data["step_name"] == "pr-merge"
+
+
+@pytest.mark.asyncio
+async def test_publish_approval_resolved(event_bus):
+    """Test publishing approval resolved event."""
+    now = datetime.now(UTC)
+
+    await event_bus.publish_approval_resolved(
+        approval_id="approval-1",
+        pipeline_id="pipeline-1",
+        status="approved",
+        responded_by="user1",
+        responded_at=now,
+    )
+
+    event = event_bus._buffer[0]
+    assert event.type == EventType.APPROVAL_RESOLVED
+    assert event.data["status"] == "approved"
+    assert event.data["responded_by"] == "user1"
+
+
+@pytest.mark.asyncio
+async def test_subscriber_count(event_bus):
+    """Test subscriber count tracking."""
+    assert event_bus.subscriber_count == 0
+
+    async def subscriber1():
+        async for _ in event_bus.subscribe():
+            break
+
+    async def subscriber2():
+        async for _ in event_bus.subscribe():
+            break
+
+    task1 = asyncio.create_task(subscriber1())
+    task2 = asyncio.create_task(subscriber2())
+
+    await asyncio.sleep(0.1)
+    assert event_bus.subscriber_count == 2
+
+    # Publish to release subscribers
+    await event_bus.publish_heartbeat()
+    await asyncio.gather(task1, task2)
+
+    # Subscribers should be cleaned up
+    assert event_bus.subscriber_count == 0
+
+
+def test_sse_event_format():
+    """Test SSE event formatting."""
+    event = SSEEvent(
+        type=EventType.PIPELINE_UPDATED,
+        data={"id": "test-123", "status": "running"},
+        id="42",
+        retry=5000,
+    )
+
+    formatted = event.format()
+
+    assert "id: 42" in formatted
+    assert "event: pipeline.updated" in formatted
+    assert "data:" in formatted
+    assert '"id": "test-123"' in formatted
+    assert '"status": "running"' in formatted
+    assert "retry: 5000" in formatted
+
+
+def test_clear_buffer(event_bus):
+    """Test clearing the event buffer."""
+    # Add some events to buffer (synchronously via _buffer)
+    event_bus._buffer.append(SSEEvent(type=EventType.HEARTBEAT, data={}, id="1"))
+    event_bus._buffer.append(SSEEvent(type=EventType.HEARTBEAT, data={}, id="2"))
+
+    assert len(event_bus._buffer) == 2
+
+    event_bus.clear_buffer()
+
+    assert len(event_bus._buffer) == 0

--- a/infrastructure/cicd-dashboard/tests/test_events_api.py
+++ b/infrastructure/cicd-dashboard/tests/test_events_api.py
@@ -1,0 +1,80 @@
+"""Tests for Events API (SSE streaming endpoints)."""
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+from app.services.event_bus import event_bus
+
+
+# Create transport for httpx to use ASGI app
+transport = ASGITransport(app=app)
+
+
+@pytest.fixture(autouse=True)
+def clear_event_bus():
+    """Clear event bus before each test."""
+    event_bus.clear_buffer()
+    yield
+    event_bus.clear_buffer()
+
+
+@pytest.mark.asyncio
+async def test_get_event_stats():
+    """Test getting event stream statistics."""
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/api/v1/events/stats")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "subscriber_count" in data
+    assert "buffer_size" in data
+    assert "buffer_capacity" in data
+    assert data["buffer_capacity"] == 100  # Default buffer size
+
+
+@pytest.mark.asyncio
+async def test_get_event_stats_with_buffer():
+    """Test event stats after buffering events."""
+    # Add some events to buffer
+    await event_bus.publish_heartbeat()
+    await event_bus.publish_pipeline_updated(
+        pipeline_id="test",
+        status="running",
+    )
+
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/api/v1/events/stats")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["buffer_size"] == 2
+
+
+@pytest.mark.asyncio
+async def test_event_stats_subscriber_count():
+    """Test subscriber count in stats."""
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/api/v1/events/stats")
+
+    assert response.status_code == 200
+    data = response.json()
+    # No active subscribers in this test
+    assert data["subscriber_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_event_buffer_capacity():
+    """Test buffer capacity is correctly reported."""
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/api/v1/events/stats")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["buffer_capacity"] == 100  # Default
+
+
+# Note: SSE streaming endpoint tests are omitted because they require
+# long-running connections that don't terminate naturally.
+# The EventBus tests in test_event_bus.py cover the core functionality.
+# Manual testing or integration tests should verify SSE streaming works.


### PR DESCRIPTION
## Summary
- Add EventBus service with in-memory pub/sub for real-time event streaming
- Add SSE endpoints (`/api/v1/events/stream`) with pipeline filtering and replay support
- Integrate event publishing into PipelineExecutor and ApprovalService
- Add heartbeat mechanism (30s intervals) and event buffering

## Event Types
| Event | Description |
|-------|-------------|
| `pipeline.created/updated/completed` | Pipeline lifecycle |
| `step.started/completed/log` | Step execution |
| `approval.requested/resolved` | Approval gates |
| `heartbeat` | Keep-alive signal |

## Test plan
- [x] 14 new EventBus tests
- [x] 4 new Events API tests
- [x] All 64 tests passing
- [x] Docker build successful
- [ ] Manual SSE streaming test (browser)

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)