### PR TITLE
feat: Ollama CPU optimization + Open WebUI integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-01-31
+
+### Added
+- **Open WebUI**: Chat interface at `/chat` for direct model interaction and parameter tuning (#85)
+- **Ollama CPU Optimization**: 7 new environment variables for CPU-only appliance (#85)
+  - `OLLAMA_FLASH_ATTENTION=1` - Flash attention for KV cache quantization
+  - `OLLAMA_KV_CACHE_TYPE=q8_0` - Halves KV cache RAM usage
+  - `OLLAMA_MAX_LOADED_MODELS=1` - Prevents loading multiple models (default was 3)
+  - `OLLAMA_KEEP_ALIVE=-1` - Model stays permanently loaded (no cold-starts)
+  - `OLLAMA_CONTEXT_LENGTH=8192` - Doubled context window
+  - `OLLAMA_LOAD_TIMEOUT=10m` - Prevents timeout on slow CPU
+  - `OLLAMA_NOPRUNE=true` - Protects pre-baked models from cleanup
+
+### Changed
+- **Context Window**: 4k to 8k tokens (same RAM usage via q8_0 KV cache quantization)
+- **Batch Size**: 512 to 128 (optimized for 4-core CPU)
+- **Inference**: Explicit CPU-only mode (`num_gpu: 0`)
+
 ## [0.10.0] - 2026-01-20
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Network Agent
 
-[![Version](https://img.shields.io/badge/version-0.10.0-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.11.0-blue.svg)](CHANGELOG.md)
 
 > **For Developers:** [CI/CD Documentation](docs/CICD.md) - Pipeline, GitHub Actions, Claude Code Skills
 
@@ -197,6 +197,7 @@ For a turnkey solution, there's a preconfigured **Proxmox VM** with everything p
 - Ollama with Qwen3 (local LLM, no API key needed)
   - **Standard:** Qwen3 4B Instruct (~3GB, optimized for CPU-only)
   - **Optional:** Qwen3 30B-A3B (~20GB, better quality with more RAM)
+- Open WebUI at `/chat` (direct model interaction + parameter tuning)
 - Caddy Reverse Proxy (HTTPS + Basic Auth)
 - PostgreSQL (Database)
 - Offline-capable (no external dependencies at runtime)
@@ -262,7 +263,8 @@ On first login:
 4. Services start automatically
 
 **Access:**
-- Web UI: `https://<VM-IP>` (credentials from first-boot)
+- Network Agent: `https://<VM-IP>` (credentials from first-boot)
+- Open WebUI Chat: `https://<VM-IP>/chat` (same credentials)
 - SSH: `ssh root@<VM-IP>`
 
 **Scan Mode (Host Network for L2/L3):**
@@ -284,7 +286,7 @@ docker compose -f docker-compose.yml -f docker-compose.online.yml up -d
 ```
 
 **Ports:**
-- 443: HTTPS Web Interface (Caddy)
+- 443: HTTPS Web Interface (Caddy) - Agent at `/`, Open WebUI at `/chat`
 - 22: SSH
 
 </details>

--- a/cli.py
+++ b/cli.py
@@ -5,7 +5,7 @@ import yaml
 from pathlib import Path
 from dotenv import load_dotenv
 
-__version__ = "0.10.0"
+__version__ = "0.11.0"
 
 
 def truncate_description(desc: str, max_length: int = 60) -> str:

--- a/infrastructure/docker/caddy/Caddyfile
+++ b/infrastructure/docker/caddy/Caddyfile
@@ -26,17 +26,24 @@ https:// {
         {$BASIC_AUTH_USER} {$BASIC_AUTH_HASH}
     }
 
-    # Reverse proxy to net-agent
-    reverse_proxy net-agent:8080 {
-        # Health check
-        health_uri /health
-        health_interval 30s
-        health_timeout 10s
+    # Open WebUI Chat Interface
+    handle_path /chat* {
+        reverse_proxy open-webui:8080
+    }
 
-        # Timeouts for long-running scans
-        transport http {
-            read_timeout 300s
-            write_timeout 300s
+    # Network Agent (default)
+    handle {
+        reverse_proxy net-agent:8080 {
+            # Health check
+            health_uri /health
+            health_interval 30s
+            health_timeout 10s
+
+            # Timeouts for long-running scans
+            transport http {
+                read_timeout 300s
+                write_timeout 300s
+            }
         }
     }
 

--- a/infrastructure/docker/config/.env.template
+++ b/infrastructure/docker/config/.env.template
@@ -20,5 +20,15 @@ SEARXNG_SECRET=GENERATED_ON_FIRST_BOOT
 # Available models: qwen3:4b-instruct-2507-q4_K_M (2.5GB, fast), qwen3:30b-a3b (18GB, better quality)
 #LLM_MODEL=qwen3:4b-instruct-2507-q4_K_M
 
+# Ollama CPU Optimization (defaults are tuned for CPU-only appliance)
+# Uncomment and change only if you need different values.
+#OLLAMA_NUM_THREADS=           # Empty = auto-detect all cores
+#OLLAMA_FLASH_ATTENTION=1      # Required for KV cache quantization
+#OLLAMA_KV_CACHE_TYPE=q8_0     # q8_0 = ~50% less KV cache RAM, q4_0 = ~75%
+#OLLAMA_KEEP_ALIVE=-1          # -1 = never unload, 5m = unload after 5min idle
+#OLLAMA_MAX_LOADED_MODELS=1    # Max concurrent models (default 3 on CPU = OOM risk)
+#OLLAMA_CONTEXT_LENGTH=8192    # Default context window for all models
+#OLLAMA_LOAD_TIMEOUT=10m       # Timeout for model loading (CPU is slow)
+
 # Version (set by CI/CD)
 VERSION=latest

--- a/infrastructure/docker/config/agent-config.yaml
+++ b/infrastructure/docker/config/agent-config.yaml
@@ -14,16 +14,14 @@ llm:
     temperature: 0.7
     max_tokens: 4096
 
-    # Context window - smaller = faster on CPU (4k is good balance)
-    # Increase to 8192 or 16384 if you have fast CPU/lots of RAM
-    max_context_tokens: 4096
+    # Context window - matches OLLAMA_CONTEXT_LENGTH=8192
+    max_context_tokens: 8192
 
-  # Ollama-specific CPU optimizations (optional, passed via API options)
-  # Uncomment to tune for your hardware:
-  # ollama:
-  #   num_ctx: 4096      # Context window (match max_context_tokens)
-  #   num_batch: 128     # Smaller batch = better for CPU
-  #   num_thread: 6      # CPU cores to use (default: all)
+  # Ollama-specific CPU optimizations (passed via API options)
+  ollama:
+    num_ctx: 8192       # Match OLLAMA_CONTEXT_LENGTH
+    num_batch: 128      # Optimized for 4-core CPU (default 512 is for GPU)
+    num_gpu: 0          # Explicit CPU-only (skip GPU detection)
 
 agent:
   max_iterations: 10

--- a/infrastructure/docker/docker-compose.scan-mode.yml
+++ b/infrastructure/docker/docker-compose.scan-mode.yml
@@ -31,6 +31,11 @@ services:
     ports:
       - "127.0.0.1:5432:5432"
 
+  # Open WebUI needs localhost access to Ollama in host mode
+  open-webui:
+    environment:
+      - OLLAMA_BASE_URL=http://127.0.0.1:11434
+
   # Caddy still handles external access
   caddy:
     environment:

--- a/infrastructure/docker/docker-compose.yml
+++ b/infrastructure/docker/docker-compose.yml
@@ -5,6 +5,8 @@
 #   Default (secure):     docker compose up -d
 #   Host network (L2/L3): docker compose -f docker-compose.yml -f docker-compose.scan-mode.yml up -d
 #   With SearXNG:         docker compose -f docker-compose.yml -f docker-compose.online.yml up -d
+#
+# Includes Open WebUI at /chat for direct model interaction and parameter tuning.
 
 services:
   net-agent:
@@ -43,10 +45,24 @@ services:
     hostname: ollama
     restart: unless-stopped
     environment:
-      # CPU Optimization: use cores-2 threads (auto-detect would use all)
+      # CPU threads (empty = auto-detect all cores)
       - OLLAMA_NUM_THREADS=${OLLAMA_NUM_THREADS:-}
-      # Keep models loaded longer (5min default, increase for frequent use)
-      - OLLAMA_KEEP_ALIVE=${OLLAMA_KEEP_ALIVE:-5m}
+      # Flash Attention: required for KV cache quantization, works on CPU
+      - OLLAMA_FLASH_ATTENTION=${OLLAMA_FLASH_ATTENTION:-1}
+      # KV cache quantization: ~50% less RAM for context (requires flash attention)
+      - OLLAMA_KV_CACHE_TYPE=${OLLAMA_KV_CACHE_TYPE:-q8_0}
+      # Never unload model (dedicated appliance, no cold-starts)
+      - OLLAMA_KEEP_ALIVE=${OLLAMA_KEEP_ALIVE:--1}
+      # Only 1 model at a time (default 3 on CPU would cause OOM)
+      - OLLAMA_MAX_LOADED_MODELS=${OLLAMA_MAX_LOADED_MODELS:-1}
+      # Default context window (8k balanced for scan reports)
+      - OLLAMA_CONTEXT_LENGTH=${OLLAMA_CONTEXT_LENGTH:-8192}
+      # CPU model loading can be slow, prevent false timeout
+      - OLLAMA_LOAD_TIMEOUT=${OLLAMA_LOAD_TIMEOUT:-10m}
+      # Don't prune pre-baked model blobs on startup
+      - OLLAMA_NOPRUNE=${OLLAMA_NOPRUNE:-true}
+      # CORS: allow Open WebUI access
+      - OLLAMA_ORIGINS=${OLLAMA_ORIGINS:-*}
     volumes:
       # Bind mount pre-baked models from base image (not Docker volume)
       - /usr/share/ollama/.ollama:/root/.ollama
@@ -80,6 +96,30 @@ services:
       net-agent:
         condition: service_healthy
 
+  open-webui:
+    image: ghcr.io/open-webui/open-webui:main
+    container_name: open-webui
+    hostname: open-webui
+    restart: unless-stopped
+    environment:
+      - OLLAMA_BASE_URL=http://ollama:11434
+      # No login required (appliance is already behind Caddy Basic Auth)
+      - WEBUI_AUTH=false
+      - ENABLE_SIGNUP=false
+    volumes:
+      - open-webui-data:/app/backend/data
+    networks:
+      - agent-net
+    depends_on:
+      ollama:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+
   postgres:
     image: postgres:16.6-alpine
     container_name: postgres
@@ -111,3 +151,4 @@ volumes:
   postgres-data:
   caddy-data:
   caddy-config:
+  open-webui-data:


### PR DESCRIPTION
## Summary
- **Ollama CPU Optimization**: 7 new environment variables tuned for CPU-only appliance (flash attention, KV cache q8_0, permanent model loading, 8k context, single model limit)
- **Open WebUI**: Chat interface at `/chat` for direct model interaction and parameter tuning
- **Agent Config**: CPU-tuned inference parameters (num_batch=128, num_gpu=0, 8k context)
- **Version**: 0.10.0 → 0.11.0

## Test Plan
- [x] Local CI passed (lint, test 240/240, security, docker build+smoke)
- [ ] Live test: Ollama settings effective on appliance
- [ ] Live test: Open WebUI accessible at /chat
- [ ] Live test: Caddy routing /chat → open-webui

Closes #85