### PR TITLE
fix: CI/CD dashboard white page with React Router basename

### DIFF
--- a/infrastructure/cicd-dashboard/frontend/src/App.tsx
+++ b/infrastructure/cicd-dashboard/frontend/src/App.tsx
@@ -6,7 +6,7 @@ import { ApprovalQueue } from '@/components/ApprovalQueue';
 
 export function App() {
   return (
-    <BrowserRouter>
+    <BrowserRouter basename="/cicd-dashboard">
       <Routes>
         <Route path="/" element={<Layout />}>
           <Route index element={<PipelineList />} />

--- a/infrastructure/cicd-dashboard/frontend/vite.config.ts
+++ b/infrastructure/cicd-dashboard/frontend/vite.config.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react'
 import path from 'path'
 
 export default defineConfig({
+  base: '/cicd-dashboard/',
   plugins: [react()],
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- Fix white page when accessing `/cicd-dashboard/` by adding `basename` to BrowserRouter
- Add `base: '/cicd-dashboard/'` to Vite config for correct asset paths

## Test plan
- [x] Dashboard renders correctly at `/cicd-dashboard/`
- [x] Pipeline data visible
- [x] No console warnings about unmatched routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)